### PR TITLE
docs(architecture): accept tech stack — Better Auth, Neon, Next.js Route Handlers [FRDAA-11]

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,8 @@
-# Architecture Decision: Initial Tech Stack (Recommendation)
+# Architecture Decision: Initial Tech Stack
 
-**Status:** RECOMMENDATION (to be reviewed by SoftwareArchitect)
+**Status:** ACCEPTED
 **Author:** Deployment bootstrap
+**Reviewed by:** SoftwareArchitect (Paperclip Agent)
 **Date:** 2026-04-10
 
 ## Context
@@ -13,7 +14,7 @@ FörderPilot is a B2B SaaS for German SMEs to automate grant/subsidy research an
 - Document generation (PDF/DOCX)
 - Robust data pipelines (grant databases, company profiles)
 
-## Recommendation (Reviewer: change only with good reason)
+## Accepted Architecture
 
 ### Monorepo
 - **pnpm workspaces + Turborepo** — standard, fast, well-supported
@@ -21,7 +22,6 @@ FörderPilot is a B2B SaaS for German SMEs to automate grant/subsidy research an
   ```
   /apps
     /web          — Next.js 16 App Router (marketing + dashboard)
-    /api          — Hono or Next.js Route Handlers (agent-facing API)
   /packages
     /db           — Drizzle ORM schema + migrations
     /shared       — Shared types, Zod schemas, utilities
@@ -34,9 +34,9 @@ FörderPilot is a B2B SaaS for German SMEs to automate grant/subsidy research an
 ### Core Stack
 - **Framework:** Next.js 16 (App Router, Server Components, Server Actions)
 - **UI:** Tailwind CSS 4 + shadcn/ui + Radix primitives
-- **Database:** Postgres via Vercel Marketplace (Neon or Supabase) + Drizzle ORM
-- **Auth:** Clerk (Vercel Marketplace native) OR Better Auth (self-hosted, already in Paperclip)
-- **API Layer:** Next.js Route Handlers with Zod validation
+- **Database:** Neon (Vercel Marketplace) + Drizzle ORM ✅ Decision documented in `docs/adr/002-database-neon.md`
+- **Auth:** Better Auth (self-hosted) ✅ Decision documented in `docs/adr/001-auth-better-auth.md`
+- **API Layer:** Next.js Route Handlers with Zod validation ✅ Decision documented in `docs/adr/003-api-layer-route-handlers.md`
 - **Background Jobs:** Vercel Workflow (durable), or Upstash QStash
 - **Deployment:** Vercel (auto-deploy from main, previews on PRs)
 - **Runtime:** Node.js 24 / Fluid Compute (default)
@@ -64,11 +64,12 @@ FörderPilot is a B2B SaaS for German SMEs to automate grant/subsidy research an
 - Multi-tenancy complexity (single-tenant first, extract later)
 - Self-hosting alternative (Vercel-only for v0)
 
-## Open Questions for SoftwareArchitect
-1. Clerk vs Better Auth (we already run Better Auth in Paperclip — reuse or separate?)
-2. Neon vs Supabase for Postgres (both on Vercel Marketplace)
-3. Do we need a separate `/api` app or are Next.js Route Handlers enough?
+## Architecture Decisions (Open Questions Resolved)
 
----
+All three open questions have been resolved and documented as ADRs in `docs/adr/`:
 
-**Architect: Review this document. If you agree, mark status ACCEPTED and proceed with scaffolding. If you disagree on any point, write a counter-ADR in `docs/adr/` with your reasoning before changing anything.**
+| # | Question | Decision | ADR |
+|---|----------|----------|-----|
+| 1 | Auth provider | **Better Auth** | [ADR-001](adr/001-auth-better-auth.md) |
+| 2 | Database provider | **Neon** | [ADR-002](adr/002-database-neon.md) |
+| 3 | API layer | **Next.js Route Handlers** | [ADR-003](adr/003-api-layer-route-handlers.md) |

--- a/docs/adr/001-auth-better-auth.md
+++ b/docs/adr/001-auth-better-auth.md
@@ -1,0 +1,42 @@
+# ADR-001: Auth Provider — Better Auth
+
+**Status:** ACCEPTED
+**Date:** 2026-04-10
+**Decider:** SoftwareArchitect
+
+## Context
+
+Two authentication options were on the table for FörderPilot:
+
+- **Clerk** — Vercel Marketplace native, managed SaaS, excellent DX out of the box, per-MAU pricing
+- **Better Auth** — open-source, self-hosted, already running in Paperclip's production stack
+
+## Decision
+
+**Use Better Auth.**
+
+## Rationale
+
+1. **Existing expertise and production parity.** Better Auth is already running in Paperclip. The engineering team has first-hand knowledge of its configuration, edge cases, and operational behaviour. Reusing it eliminates a ramp-up period and an unknown support surface.
+
+2. **Cost at scale.** Clerk charges per monthly active user. For a B2B platform targeting German SMEs — where enterprise customers can have dozens of employee seats — MAU pricing becomes expensive quickly. Better Auth has no per-user fee beyond hosting.
+
+3. **No additional vendor lock-in.** We are already Vercel-dependent for deployment and compute. Adding a mandatory Clerk dependency for auth increases lock-in without a countervailing benefit that Better Auth cannot provide.
+
+4. **Feature parity.** Better Auth supports all required features: email/password, OAuth providers, session management, role-based access, and multi-tenant organization primitives — sufficient for v0 and beyond.
+
+5. **Vercel Marketplace availability is not a deciding factor.** Clerk's Marketplace listing simplifies initial provisioning but does not meaningfully reduce ongoing operational cost or complexity for a team already managing Better Auth.
+
+## Consequences
+
+- `packages/db` will include Better Auth schema tables alongside Drizzle migrations.
+- Auth configuration lives in `apps/web` (Next.js plugin / middleware) and reuses patterns from Paperclip.
+- No Clerk account or API keys required; no per-MAU billing.
+- Self-hosted auth requires the team to handle security patches for Better Auth packages — acceptable given existing practice.
+
+## Alternatives Considered
+
+### Clerk
+- **Pro:** Zero-config Vercel integration, hosted UI components, great DX for greenfield projects.
+- **Con:** MAU-based pricing escalates with enterprise customers; adds a new vendor dependency; team has no existing production experience with it.
+- **Rejected because:** cost risk at scale outweighs DX advantage, and Better Auth already satisfies all requirements.

--- a/docs/adr/002-database-neon.md
+++ b/docs/adr/002-database-neon.md
@@ -1,0 +1,41 @@
+# ADR-002: Database Provider — Neon
+
+**Status:** ACCEPTED
+**Date:** 2026-04-10
+**Decider:** SoftwareArchitect
+
+## Context
+
+Both Neon and Supabase are available on the Vercel Marketplace and provide managed Postgres. The stack already decided on Drizzle ORM, which works with both.
+
+- **Neon** — serverless Postgres-as-a-service, purpose-built for Vercel's Fluid Compute, database branching for preview environments
+- **Supabase** — Postgres platform with built-in auth, storage, realtime subscriptions, REST/GraphQL auto-generated APIs
+
+## Decision
+
+**Use Neon.**
+
+## Rationale
+
+1. **Right-sized for the stack.** Supabase is a platform, not just a database. It bundles auth, storage, realtime, and auto-generated APIs. We are using Better Auth (ADR-001), have no immediate need for realtime subscriptions or auto-generated REST, and plan to control our API surface explicitly. Supabase's extras go unused and add operational surface.
+
+2. **Serverless-first design matches Vercel Fluid Compute.** Neon's HTTP driver and connection pooler (Neon serverless driver) are specifically optimised for ephemeral serverless runtimes — the exact deployment model we are using. Cold-start connection overhead is eliminated.
+
+3. **Database branching for preview deployments.** Neon creates instant database branches per branch/PR, mirroring Vercel's preview deployment model. Each PR gets an isolated database state without full data copies. This significantly improves integration testing and review quality.
+
+4. **Drizzle-first workflow.** Neon + Drizzle is a well-documented, widely used combination with tooling (Drizzle Studio, `drizzle-kit push/generate/migrate`) that works seamlessly. No Supabase-specific migration tooling required.
+
+5. **Cost.** Neon's free tier and scale-to-zero model keeps costs near-zero during early development. Supabase requires a paid plan for production branching and advanced features.
+
+## Consequences
+
+- `packages/db` uses Drizzle ORM with the Neon serverless adapter (`@neondatabase/serverless`).
+- `.env` stores `DATABASE_URL` pointing to the Neon connection string; preview branches automatically get isolated `DATABASE_URL` values via Vercel Marketplace integration.
+- Supabase is not provisioned; no Supabase SDK in the dependency tree.
+
+## Alternatives Considered
+
+### Supabase
+- **Pro:** Feature-rich platform; realtime and storage available if needed later; strong open-source community.
+- **Con:** Bundles auth/storage/realtime we don't need; migration tooling is more opinionated; branching requires higher-tier plan; connection model is less optimised for pure serverless.
+- **Rejected because:** Neon is leaner, better matched to our serverless deployment target, and provides the database branching feature we need without paying for features we explicitly don't use.

--- a/docs/adr/003-api-layer-route-handlers.md
+++ b/docs/adr/003-api-layer-route-handlers.md
@@ -1,0 +1,42 @@
+# ADR-003: API Layer — Next.js Route Handlers
+
+**Status:** ACCEPTED
+**Date:** 2026-04-10
+**Decider:** SoftwareArchitect
+
+## Context
+
+Two options were proposed for the agent-facing API surface:
+
+- **Separate `/api` app using Hono** — a lightweight TypeScript HTTP framework, deployed as a distinct Vercel project or serverless function group
+- **Next.js Route Handlers** — API routes co-located in `apps/web` under `app/api/`, using Next.js's built-in handler conventions
+
+## Decision
+
+**Use Next.js Route Handlers (co-located in `apps/web`).**
+
+## Rationale
+
+1. **Unnecessary complexity at v0.** A separate Hono app introduces a second deployment unit, second set of environment variables, potential CORS surface, and monorepo plumbing (separate `apps/api` workspace, distinct Vercel project, independent CI steps). For a v0 product with a small team, that overhead is not justified.
+
+2. **Feature parity for current requirements.** Next.js Route Handlers with Zod validation satisfy all current API requirements: typed request/response, middleware via `middleware.ts`, streaming support (via Response streaming), and Vercel-native deployment. There is no feature gap that Hono fills for us today.
+
+3. **Shared code within one deployment.** Route Handlers live in the same Next.js app and can import `packages/db`, `packages/shared`, and server-only utilities without network hops or serialisation overhead. A separate Hono app would require explicit package exports and inter-service calls or a shared monorepo build.
+
+4. **TypeScript DX is comparable.** Modern Next.js Route Handlers with `next-safe-action` or plain Zod parsing provide typed APIs. Hono's `hono/zod-validator` is excellent but not a decisive advantage given we're already in a Next.js monorepo.
+
+5. **Extraction path is clear.** If the agent-facing API needs independent scaling, rate limiting, or a separate deployment in the future, extracting it to a standalone Hono app is straightforward — the Route Handler logic maps 1:1. The decision is reversible; the cost of waiting is low.
+
+## Consequences
+
+- `apps/web/app/api/` contains all agent-facing endpoints as Route Handlers.
+- Zod schemas for request/response validation live in `packages/shared` and are imported by both Route Handlers and agent client code.
+- No `apps/api` workspace is scaffolded for v0. The monorepo structure drops the `/api` app directory.
+- If traffic patterns or isolation requirements change post-v0, an `apps/api` Hono workspace can be introduced without changing the API contract (same paths, same Zod schemas).
+
+## Alternatives Considered
+
+### Separate Hono app (`apps/api`)
+- **Pro:** Framework purpose-built for APIs; RPC-style type safety (`hono/client`); independent scaling; cleaner separation of concerns for large teams.
+- **Con:** Separate deployment, extra Vercel project, CORS configuration, monorepo coordination overhead; no feature we need today that Route Handlers can't provide.
+- **Rejected because:** Premature separation at v0 stage adds cost without benefit. Revisit if the API surface grows significantly or team size requires hard boundaries.


### PR DESCRIPTION
## Summary

This PR resolves [FRDAA-11](https://github.com/felitsch/foerderpilot-platform) — Phase 1 Architecture Review & Tech Stack Decisions.

### Changes

- `docs/ARCHITECTURE.md` — status changed from `RECOMMENDATION` to `ACCEPTED`; open questions replaced with decision table
- `docs/adr/001-auth-better-auth.md` — **Better Auth** chosen over Clerk
- `docs/adr/002-database-neon.md` — **Neon** chosen over Supabase
- `docs/adr/003-api-layer-route-handlers.md` — **Next.js Route Handlers** chosen over separate Hono app

### Decisions

| # | Question | Decision | Rationale |
|---|----------|----------|----------|
| 1 | Auth | **Better Auth** | Already in Paperclip production; no per-MAU cost; no additional vendor lock-in |
| 2 | Database | **Neon** | Serverless-first design; DB branching for PR previews; leaner than Supabase for our needs |
| 3 | API Layer | **Next.js Route Handlers** | Co-located simplicity at v0; extractable to Hono later if needed |

## Test plan

- [ ] Review `docs/ARCHITECTURE.md` for correctness and completeness
- [ ] Review each ADR for sound reasoning
- [ ] Confirm decisions align with company stack and budget expectations
- [ ] Approve and merge to unblock Phase 2 scaffolding (FRDAA-12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)