### PR TITLE
feat(monorepo): Phase 2a — root scaffold + packages/db + packages/shared [FRDAA-12]

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "es5"
+    }
+  },
+  "files": {
+    "ignore": [
+      "node_modules",
+      ".next",
+      "dist",
+      ".turbo",
+      "*.tsbuildinfo"
+    ]
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: foerderpilot
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "foerderpilot-platform",
+  "private": true,
+  "version": "0.0.0",
+  "packageManager": "pnpm@9.0.0",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint",
+    "typecheck": "turbo run typecheck",
+    "test": "turbo run test",
+    "format": "biome format --write .",
+    "check": "biome check --write ."
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "turbo": "^2.3.3",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,0 +1,4 @@
+# Neon Postgres connection string
+# Production: set in Vercel via Neon Marketplace integration
+# Local development: use the docker-compose Postgres instance below
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/foerderpilot"

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "drizzle-kit";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is required");
+}
+
+export default defineConfig({
+  schema: "./src/schema.ts",
+  out: "./src/migrations",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: process.env.DATABASE_URL,
+  },
+});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@foerderpilot/db",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "tsx src/migrate.ts",
+    "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@neondatabase/serverless": "^0.10.4",
+    "drizzle-orm": "^0.38.3"
+  },
+  "devDependencies": {
+    "drizzle-kit": "^0.30.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,11 @@
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+import * as schema from "./schema";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is required");
+}
+
+const sql = neon(process.env.DATABASE_URL);
+
+export const db = drizzle(sql, { schema });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,2 @@
+export { db } from "./client";
+export * from "./schema";

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,0 +1,21 @@
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+import { migrate } from "drizzle-orm/neon-http/migrator";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is required");
+}
+
+const sql = neon(process.env.DATABASE_URL);
+const db = drizzle(sql);
+
+async function main() {
+  console.log("Running migrations...");
+  await migrate(db, { migrationsFolder: "./src/migrations" });
+  console.log("Migrations complete.");
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,0 +1,11 @@
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+export const waitlist = pgTable("waitlist", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  email: text("email").notNull().unique(),
+  companyName: text("company_name").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type Waitlist = typeof waitlist.$inferSelect;
+export type NewWaitlist = typeof waitlist.$inferInsert;

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@foerderpilot/shared",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,2 @@
+export { waitlistFormSchema } from "./schemas/waitlist";
+export type { WaitlistFormData } from "./schemas/waitlist";

--- a/packages/shared/src/schemas/waitlist.ts
+++ b/packages/shared/src/schemas/waitlist.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const waitlistFormSchema = z.object({
+  email: z
+    .string()
+    .min(1, "Email is required")
+    .email("Please enter a valid email address"),
+  companyName: z
+    .string()
+    .min(2, "Company name must be at least 2 characters")
+    .max(100, "Company name must be at most 100 characters"),
+});
+
+export type WaitlistFormData = z.infer<typeof waitlistFormSchema>;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "exclude": ["node_modules"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "ui": "tui",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {
+      "dependsOn": ["^build"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env.test*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **Monorepo root**: `package.json` (pnpm workspaces), `pnpm-workspace.yaml`, `turbo.json` (build/dev/lint/typecheck/test pipeline), `biome.json` (format + lint), root `tsconfig.json`
- **`packages/db`**: Drizzle ORM + Neon; `waitlist` table (uuid id, email unique, company_name, created_at); drizzle config; migrate script; `.env.example`
- **`packages/shared`**: Zod waitlist form schema; inferred TypeScript types; index export
- **`docker-compose.yml`**: local Postgres 16 for dev

## Architecture alignment

Implements decisions from FRDAA-11: Neon (`@neondatabase/serverless`) + Drizzle ORM.

## Test Plan

- [ ] `docker compose up -d` starts Postgres on port 5432
- [ ] Copy `packages/db/.env.example` → `.env.local`, set `DATABASE_URL`
- [ ] `pnpm install` resolves all workspace deps
- [ ] `pnpm --filter @foerderpilot/db db:generate` generates migration
- [ ] `pnpm --filter @foerderpilot/db db:migrate` creates `waitlist` table
- [ ] `pnpm --filter @foerderpilot/shared typecheck` passes
- [ ] `pnpm biome check .` passes

CTO review requested per FRDAA-12 workflow.