### PR TITLE
test(e2e): Playwright smoke tests for landing page [FRDAA-17]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,32 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - run: pnpm turbo build
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: [build]
+    env:
+      PLAYWRIGHT_BASE_URL: ${{ secrets.E2E_BASE_URL || 'http://localhost:3000' }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @foerderpilot/web exec playwright install --with-deps chromium
+      - run: pnpm --filter @foerderpilot/web build
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      - run: pnpm --filter @foerderpilot/web e2e
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ secrets.E2E_BASE_URL }}
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 7

--- a/apps/web/e2e/landing.spec.ts
+++ b/apps/web/e2e/landing.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Landing Page — Smoke Tests", () => {
+  test("page loads without errors", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("pageerror", (err) => errors.push(err.message));
+
+    const response = await page.goto("/");
+    expect(response?.status()).not.toBe(404);
+    expect(errors).toHaveLength(0);
+  });
+
+  test("hero section is visible", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: /Fördermittel/i, level: 1 }),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: /Warteliste/i })).toBeVisible();
+  });
+
+  test("value proposition section is visible", async ({ page }) => {
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: /FörderPilot für Sie/i }),
+    ).toBeVisible();
+    await expect(page.getByText("Automatische Förderrecherche")).toBeVisible();
+    await expect(page.getByText("KI-gestützte Antragsvorbereitung")).toBeVisible();
+    await expect(page.getByText("Integrierter Compliance-Check")).toBeVisible();
+  });
+
+  test("footer with Impressum link is visible", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("link", { name: "Impressum" })).toBeVisible();
+  });
+
+  test("Impressum page loads", async ({ page }) => {
+    await page.goto("/impressum");
+    await expect(
+      page.getByRole("heading", { name: "Impressum", level: 1 }),
+    ).toBeVisible();
+    await expect(page.getByText(/§ 5 TMG/)).toBeVisible();
+  });
+});
+
+test.describe("Waitlist Form", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/#warteliste");
+  });
+
+  test("form is visible", async ({ page }) => {
+    await expect(page.getByRole("heading", { name: /Früher Zugang/i })).toBeVisible();
+    await expect(page.getByLabel(/E-Mail/i)).toBeVisible();
+    await expect(page.getByLabel(/Firmenname/i)).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /vormerken/i }),
+    ).toBeVisible();
+  });
+
+  test("empty submit shows browser validation", async ({ page }) => {
+    // HTML5 required attributes prevent submission — button stays enabled but form won't submit
+    const emailInput = page.getByLabel(/E-Mail/i);
+    await expect(emailInput).toHaveAttribute("required");
+    const companyInput = page.getByLabel(/Firmenname/i);
+    await expect(companyInput).toHaveAttribute("required");
+  });
+
+  test("submit button is enabled by default", async ({ page }) => {
+    await expect(
+      page.getByRole("button", { name: /vormerken/i }),
+    ).toBeEnabled();
+  });
+
+  test("shows loading state on submit", async ({ page }) => {
+    await page.getByLabel(/E-Mail/i).fill("test@example.de");
+    await page.getByLabel(/Firmenname/i).fill("Test GmbH");
+    await page.getByRole("button", { name: /vormerken/i }).click();
+    // Button should show loading state immediately after click
+    await expect(page.getByText(/Wird eingetragen/i)).toBeVisible({
+      timeout: 2000,
+    });
+  });
+});
+
+test.describe("Responsive Layout", () => {
+  test("mobile (375px) — page is usable", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", { name: /Fördermittel/i, level: 1 }),
+    ).toBeVisible();
+    await expect(page.getByLabel(/E-Mail/i)).toBeVisible();
+    await expect(page.getByLabel(/Firmenname/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: "Impressum" })).toBeVisible();
+  });
+
+  test("desktop (1280px) — page is usable", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", { name: /Fördermittel/i, level: 1 }),
+    ).toBeVisible();
+    await expect(page.getByLabel(/E-Mail/i)).toBeVisible();
+    await expect(page.getByLabel(/Firmenname/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: "Impressum" })).toBeVisible();
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@foerderpilot/db": "workspace:*",
@@ -23,6 +26,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.51.1",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "mobile-chrome",
+      use: { ...devices["Pixel 5"] },
+    },
+  ],
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: "pnpm dev",
+        url: "http://localhost:3000",
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+});


### PR DESCRIPTION
## Summary

Adds Playwright E2E test suite for the landing page.

## Tests

**Smoke Tests (`landing.spec.ts`)**
- Page loads without errors (no 404, no JS errors)
- Hero section visible (H1 + CTA button)
- Value proposition section visible (3 cards)
- Footer with Impressum link visible
- Impressum page loads with §5 TMG content

**Waitlist Form Tests**
- Form is visible (email + company inputs + submit button)
- Empty fields have `required` attributes (browser-native validation)
- Submit button enabled by default
- Shows loading state immediately on submit

**Responsive Tests**
- Mobile 375px: hero, form, footer all visible
- Desktop 1280px: hero, form, footer all visible

## Setup

- `playwright.config.ts` in `apps/web/`: Chromium + mobile-chrome, auto webServer on dev
- Tests in `apps/web/e2e/landing.spec.ts`
- `PLAYWRIGHT_BASE_URL` env var to override target URL (CI or Vercel preview)
- New CI job `e2e` runs after `build`, uploads HTML report artifact

## Test plan

- [ ] `pnpm --filter @foerderpilot/web exec playwright install chromium`
- [ ] `pnpm --filter @foerderpilot/web e2e` (starts dev server automatically)
- [ ] All 11 tests pass

Linked issue: FRDAA-17