### PR TITLE
chore: rename FörderPilot → Foerderis in infra and docs [FRDAA-24]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 services:
   postgres:
     image: postgres:16-alpine
+    restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: foerderpilot
+      POSTGRES_DB: foerderis
     ports:
       - "5432:5432"
     volumes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,10 +7,18 @@
 
 ## Context
 
-FörderPilot is a B2B SaaS for German SMEs to automate grant/subsidy research and applications. The platform needs:
-- Public marketing site
-- Authenticated customer dashboard
-- Agent-facing APIs for the Paperclip backend team
+Foerderis is an internal consulting platform for German SME grant/subsidy advisory. The platform consists of three distinct surfaces:
+
+1. **Marketing Landingpage** — public-facing, presents the service offering
+2. **Kundenportal (Customer Portal)** — authenticated area for clients to view their grant applications and consulting status
+3. **Backend-Admin** — internal tool for consultants to manage clients, documents, and workflows
+
+**Important:** Foerderis is **not a SaaS product**. There is no self-service onboarding, no demo mode, and no subscription billing. Client onboarding is handled exclusively by the consulting team. The revenue model is a success-fee (Erfolgshonorar) arrangement — no recurring subscriptions.
+
+The platform needs:
+- Public marketing site (Landingpage)
+- Authenticated customer portal (Kundenportal)
+- Internal backend-admin for consultants
 - Document generation (PDF/DOCX)
 - Robust data pipelines (grant databases, company profiles)
 
@@ -21,7 +29,8 @@ FörderPilot is a B2B SaaS for German SMEs to automate grant/subsidy research an
 - Structure:
   ```
   /apps
-    /web          — Next.js 16 App Router (marketing + dashboard)
+    /web          — Next.js 16 App Router (marketing + Kundenportal)
+    /admin        — Next.js 16 App Router (Backend-Admin, internal only)
   /packages
     /db           — Drizzle ORM schema + migrations
     /shared       — Shared types, Zod schemas, utilities
@@ -63,6 +72,8 @@ FörderPilot is a B2B SaaS for German SMEs to automate grant/subsidy research an
 - Mobile apps (web-first, mobile-responsive)
 - Multi-tenancy complexity (single-tenant first, extract later)
 - Self-hosting alternative (Vercel-only for v0)
+- Self-service / demo mode (consulting-led onboarding only)
+- Subscription billing (Erfolgshonorar model only)
 
 ## Architecture Decisions (Open Questions Resolved)
 

--- a/docs/adr/001-auth-better-auth.md
+++ b/docs/adr/001-auth-better-auth.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-Two authentication options were on the table for FörderPilot:
+Two authentication options were on the table for Foerderis:
 
 - **Clerk** — Vercel Marketplace native, managed SaaS, excellent DX out of the box, per-MAU pricing
 - **Better Auth** — open-source, self-hosted, already running in Paperclip's production stack
@@ -19,7 +19,7 @@ Two authentication options were on the table for FörderPilot:
 
 1. **Existing expertise and production parity.** Better Auth is already running in Paperclip. The engineering team has first-hand knowledge of its configuration, edge cases, and operational behaviour. Reusing it eliminates a ramp-up period and an unknown support surface.
 
-2. **Cost at scale.** Clerk charges per monthly active user. For a B2B platform targeting German SMEs — where enterprise customers can have dozens of employee seats — MAU pricing becomes expensive quickly. Better Auth has no per-user fee beyond hosting.
+2. **Cost at scale.** Clerk charges per monthly active user. For a platform targeting German SMEs — where clients can have dozens of employee seats — MAU pricing becomes expensive quickly. Better Auth has no per-user fee beyond hosting.
 
 3. **No additional vendor lock-in.** We are already Vercel-dependent for deployment and compute. Adding a mandatory Clerk dependency for auth increases lock-in without a countervailing benefit that Better Auth cannot provide.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "foerderpilot-platform",
+  "name": "foerderis-platform",
   "private": true,
   "version": "0.0.0",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Summary

- Add `package.json` (root) with `"name": "foerderis-platform"`
- Add `docker-compose.yml` with `POSTGRES_DB: foerderis`
- Update `docs/adr/001-auth-better-auth.md`: replace `FörderPilot` with `Foerderis`
- Update `docs/ARCHITECTURE.md`: reposition from B2B SaaS → internal consulting platform (Landingpage + Kundenportal + Backend-Admin), remove self-service/demo/subscription references, add Erfolgshonorar note

## Verification

```bash
rg -l "foerderpilot|FörderPilot" docker-compose.yml package.json docs/
# → no output
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)