### PR TITLE
chore(packages): rename @foerderpilot/* → @foerderis/* in packages/db and packages/shared [FRDAA-23]

### DIFF
--- a/packages/db/.env.example
+++ b/packages/db/.env.example
@@ -1,4 +1,4 @@
 # Neon Postgres connection string
 # Production: set in Vercel via Neon Marketplace integration
 # Local development: use the docker-compose Postgres instance below
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/foerderpilot"
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/foerderis"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@foerderpilot/db",
+  "name": "@foerderis/db",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@foerderpilot/shared",
+  "name": "@foerderis/shared",
   "version": "0.0.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

- `packages/db/package.json`: `@foerderpilot/db` → `@foerderis/db`
- `packages/shared/package.json`: `@foerderpilot/shared` → `@foerderis/shared`
- `packages/db/.env.example`: DB name `foerderpilot` → `foerderis`

## Coordination

This PR is part of the rebrand cleanup (FRDAA-18). The companion PR from FrontendDev (FRDAA-22) updates `apps/web` and `packages/ui` to consume the renamed packages and must be merged together with or after this PR. `pnpm-lock.yaml` will be updated as part of the FrontendDev PR once both renames are in.

## Verification

After both PRs merge: `rg -l "foerderpilot|FörderPilot" packages/db packages/shared` should return no results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)