### PR TITLE
feat: Landingpage Copy v2 — Foerderis Neupositionierung

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,9 +3,9 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "FörderPilot",
+  title: "Foerderis — Fördermittelberatung auf Erfolgsbasis",
   description:
-    "Automatisierte Fördermittel-Recherche, Antragsvorbereitung und Compliance-Prüfung für deutsche KMUs.",
+    "Wir werden nur bezahlt, wenn Sie gefördert werden. Ein KI-Team sucht rund um die Uhr Förderprogramme für den deutschen Mittelstand — 10 % nur bei Bewilligung.",
 };
 
 export default function RootLayout({

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -35,13 +35,12 @@ export default function Home() {
             Fördermittelberatung für den deutschen Mittelstand
           </p>
           <h1 className="mb-6 text-4xl font-bold leading-tight tracking-tight text-foreground sm:text-5xl md:text-6xl">
-            Wir werden nur bezahlt,{" "}
-            <span className="text-primary">wenn Sie gefördert werden.</span>
+            Wir werden nur bezahlt, <span className="text-primary">wenn Sie gefördert werden.</span>
           </h1>
           <p className="mx-auto mb-10 max-w-xl text-lg text-muted-foreground sm:text-xl">
-            Ein KI-Team sucht rund um die Uhr für Sie — findet passende Förderprogramme,
-            formuliert Anträge und überwacht Fristen. Sie zahlen 10 %, und nur dann, wenn die
-            Förderung bewilligt wurde.
+            Ein KI-Team sucht rund um die Uhr für Sie — findet passende Förderprogramme, formuliert
+            Anträge und überwacht Fristen. Sie zahlen 10 %, und nur dann, wenn die Förderung
+            bewilligt wurde.
           </p>
           <Button asChild size="lg">
             <a href="#kontakt">Jetzt unverbindlich anfragen</a>
@@ -129,15 +128,18 @@ export default function Home() {
                 <li className="flex items-start gap-3">
                   <Clock className="mt-0.5 size-4 shrink-0 text-primary" />
                   <span>
-                    <strong className="text-foreground">Mittelstand mit 10 bis 250 Mitarbeitern</strong>{" "}
-                    — GmbH, GmbH &amp; Co. KG, AG. Unternehmen mit greifbarer deutscher Wertschöpfung.
+                    <strong className="text-foreground">
+                      Mittelstand mit 10 bis 250 Mitarbeitern
+                    </strong>{" "}
+                    — GmbH, GmbH &amp; Co. KG, AG. Unternehmen mit greifbarer deutscher
+                    Wertschöpfung.
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
                   <Clock className="mt-0.5 size-4 shrink-0 text-primary" />
                   <span>
-                    Geschäftsführer und kaufmännische Leitungen, die wissen, dass Förderung
-                    da wäre — aber keine Zeit haben, ihr nachzujagen.
+                    Geschäftsführer und kaufmännische Leitungen, die wissen, dass Förderung da wäre
+                    — aber keine Zeit haben, ihr nachzujagen.
                   </span>
                 </li>
                 <li className="flex items-start gap-3">
@@ -200,8 +202,8 @@ export default function Home() {
             Unverbindlich anfragen
           </h2>
           <p className="mb-8 text-center text-muted-foreground">
-            Wir prüfen, ob Foerderis zu Ihrem Unternehmen passt — und melden uns innerhalb von
-            zwei Werktagen.
+            Wir prüfen, ob Foerderis zu Ihrem Unternehmen passt — und melden uns innerhalb von zwei
+            Werktagen.
           </p>
           <WaitlistForm />
         </div>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,26 +1,26 @@
 import { WaitlistForm } from "@/components/waitlist-form";
 import { Button } from "@foerderpilot/ui";
 import { Card, CardContent } from "@foerderpilot/ui";
-import { FileText, Search, ShieldCheck } from "lucide-react";
+import { Clock, FileText, ShieldCheck } from "lucide-react";
 
-const VALUE_PROPS = [
+const HOW_IT_WORKS = [
   {
-    icon: Search,
-    title: "Automatische Förderrecherche",
+    step: "1",
+    title: "Wir lernen Ihr Unternehmen kennen",
     description:
-      "Wir scannen täglich alle verfügbaren Förderprogramme auf Bundes-, Landes- und EU-Ebene — und zeigen Ihnen nur die, die wirklich zu Ihrem Unternehmen passen.",
+      "Ein kurzes Gespräch. Wir erfassen Branche, Größe, Investitionsvorhaben und bisherige Förderhistorie — einmalig, ohne laufenden Aufwand Ihrerseits.",
   },
   {
-    icon: FileText,
-    title: "KI-gestützte Antragsvorbereitung",
+    step: "2",
+    title: "Unser KI-Team arbeitet rund um die Uhr",
     description:
-      "Vom passenden Förderprogramm zum fertigen Entwurf in Minuten. FörderPilot erstellt auf Basis Ihrer Angaben einen vollständigen Antragsentwurf.",
+      "Spezialisierte KI-Agenten scannen täglich alle deutschen und europäischen Förderprogramme, gleichen Treffer mit Ihrem Profil ab und formulieren revisionssichere Anträge.",
   },
   {
-    icon: ShieldCheck,
-    title: "Integrierter Compliance-Check",
+    step: "3",
+    title: "Sie zahlen nur bei Bewilligung",
     description:
-      "Automatische Prüfung aller Fördervoraussetzungen und Nachweispflichten — damit Ihr Antrag beim ersten Versuch genehmigt wird.",
+      "10 % der bewilligten Fördersumme — kein Abo, keine Grundgebühr, kein Risiko. Wenn das Geld auf Ihrem Konto eingeht, stellen wir Rechnung.",
   },
 ];
 
@@ -32,36 +32,41 @@ export default function Home() {
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-10%,oklch(0.4_0_0),transparent)]" />
         <div className="relative mx-auto max-w-3xl">
           <p className="mb-4 text-sm font-semibold uppercase tracking-widest text-muted-foreground">
-            Jetzt in der Beta-Phase
+            Fördermittelberatung für den deutschen Mittelstand
           </p>
           <h1 className="mb-6 text-4xl font-bold leading-tight tracking-tight text-foreground sm:text-5xl md:text-6xl">
-            Nie wieder <span className="text-primary">Fördermittel</span> verpassen.
+            Wir werden nur bezahlt,{" "}
+            <span className="text-primary">wenn Sie gefördert werden.</span>
           </h1>
           <p className="mx-auto mb-10 max-w-xl text-lg text-muted-foreground sm:text-xl">
-            KI-gestützte Förderrecherche, Antragsvorbereitung und Compliance-Prüfung — speziell für
-            den deutschen Mittelstand.
+            Ein KI-Team sucht rund um die Uhr für Sie — findet passende Förderprogramme,
+            formuliert Anträge und überwacht Fristen. Sie zahlen 10 %, und nur dann, wenn die
+            Förderung bewilligt wurde.
           </p>
           <Button asChild size="lg">
-            <a href="#warteliste">Jetzt auf die Warteliste</a>
+            <a href="#kontakt">Jetzt unverbindlich anfragen</a>
           </Button>
         </div>
       </section>
 
-      {/* Value Proposition */}
-      <section className="px-4 py-20" aria-labelledby="value-heading">
+      {/* How it works */}
+      <section className="px-4 py-20" aria-labelledby="how-heading">
         <div className="mx-auto max-w-5xl">
           <h2
-            id="value-heading"
-            className="mb-12 text-center text-3xl font-bold tracking-tight text-foreground"
+            id="how-heading"
+            className="mb-4 text-center text-3xl font-bold tracking-tight text-foreground"
           >
-            Was FörderPilot für Sie tut
+            So funktioniert es
           </h2>
+          <p className="mb-12 text-center text-muted-foreground">
+            Drei Schritte — und dann arbeiten wir, nicht Sie.
+          </p>
           <div className="grid gap-6 sm:grid-cols-3">
-            {VALUE_PROPS.map(({ icon: Icon, title, description }) => (
-              <Card key={title}>
+            {HOW_IT_WORKS.map(({ step, title, description }) => (
+              <Card key={step}>
                 <CardContent className="flex flex-col gap-4 p-6">
-                  <div className="flex size-10 items-center justify-center rounded-lg bg-secondary">
-                    <Icon className="size-5 text-foreground" />
+                  <div className="flex size-10 items-center justify-center rounded-lg bg-secondary text-lg font-bold text-foreground">
+                    {step}
                   </div>
                   <h3 className="text-base font-semibold text-foreground">{title}</h3>
                   <p className="text-sm leading-relaxed text-muted-foreground">{description}</p>
@@ -72,17 +77,131 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Waitlist Form */}
-      <section id="warteliste" className="px-4 py-20" aria-labelledby="waitlist-heading">
+      {/* Pricing — prominent */}
+      <section className="px-4 py-20" aria-labelledby="pricing-heading">
+        <div className="mx-auto max-w-2xl">
+          <div className="rounded-2xl border border-border bg-secondary/30 p-8 text-center">
+            <h2
+              id="pricing-heading"
+              className="mb-4 text-3xl font-bold tracking-tight text-foreground"
+            >
+              10 % — nur bei Bewilligung
+            </h2>
+            <p className="mb-6 text-muted-foreground">
+              Keine Einrichtungsgebühr. Keine monatliche Pauschale. Kein Retainer.
+            </p>
+            <ul className="mb-6 space-y-3 text-sm text-muted-foreground">
+              <li className="flex items-start gap-2">
+                <ShieldCheck className="mt-0.5 size-4 shrink-0 text-primary" />
+                <span>Wenn wir keine passende Förderung finden — zahlen Sie nichts.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <ShieldCheck className="mt-0.5 size-4 shrink-0 text-primary" />
+                <span>Wenn der Antrag nicht durchgeht — zahlen Sie nichts.</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <ShieldCheck className="mt-0.5 size-4 shrink-0 text-primary" />
+                <span>
+                  Nur wenn das Geld auf Ihrem Konto eingeht, stellen wir 10 % in Rechnung.
+                </span>
+              </li>
+            </ul>
+            <p className="text-xs text-muted-foreground">
+              Das entspricht der unteren Hälfte des marktüblichen Honorars für deutsche
+              Fördermittelberater — ohne das übliche Vorabrisiko.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Für wen */}
+      <section className="px-4 py-20" aria-labelledby="audience-heading">
+        <div className="mx-auto max-w-5xl">
+          <div className="grid gap-12 md:grid-cols-2">
+            <div>
+              <h2
+                id="audience-heading"
+                className="mb-6 text-3xl font-bold tracking-tight text-foreground"
+              >
+                Für wen wir arbeiten
+              </h2>
+              <ul className="space-y-4 text-muted-foreground">
+                <li className="flex items-start gap-3">
+                  <Clock className="mt-0.5 size-4 shrink-0 text-primary" />
+                  <span>
+                    <strong className="text-foreground">Mittelstand mit 10 bis 250 Mitarbeitern</strong>{" "}
+                    — GmbH, GmbH &amp; Co. KG, AG. Unternehmen mit greifbarer deutscher Wertschöpfung.
+                  </span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <Clock className="mt-0.5 size-4 shrink-0 text-primary" />
+                  <span>
+                    Geschäftsführer und kaufmännische Leitungen, die wissen, dass Förderung
+                    da wäre — aber keine Zeit haben, ihr nachzujagen.
+                  </span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <Clock className="mt-0.5 size-4 shrink-0 text-primary" />
+                  <span>
+                    Branchen: Maschinenbau, Fertigung, Handwerk, mittelständische IT, Energie, Bau.
+                  </span>
+                </li>
+              </ul>
+            </div>
+
+            {/* Was wir NICHT sind */}
+            <div>
+              <h2 className="mb-6 text-3xl font-bold tracking-tight text-foreground">
+                Was wir nicht sind
+              </h2>
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                <li className="flex items-start gap-2">
+                  <FileText className="mt-0.5 size-4 shrink-0" />
+                  <span>
+                    <strong className="text-foreground">Kein SaaS-Tool.</strong> Sie bedienen keine
+                    Software. Wir übernehmen die Arbeit vollständig.
+                  </span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <FileText className="mt-0.5 size-4 shrink-0" />
+                  <span>
+                    <strong className="text-foreground">Kein Chatbot.</strong> Kein Self-Service,
+                    kein Login-Bereich, keine Matching-Datenbank zum Selbstdurchsuchen.
+                  </span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <FileText className="mt-0.5 size-4 shrink-0" />
+                  <span>
+                    <strong className="text-foreground">Nicht für Startups.</strong> Unsere Methodik
+                    ist auf etablierten deutschen Mittelstand ausgerichtet — nicht auf pre-revenue
+                    Gründungsvorhaben.
+                  </span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <FileText className="mt-0.5 size-4 shrink-0" />
+                  <span>
+                    <strong className="text-foreground">Nicht international.</strong> Wir arbeiten
+                    ausschließlich mit deutschen Unternehmen nach deutschem Recht.
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Lead Capture Form */}
+      <section id="kontakt" className="px-4 py-20" aria-labelledby="contact-heading">
         <div className="mx-auto max-w-md">
           <h2
-            id="waitlist-heading"
+            id="contact-heading"
             className="mb-2 text-center text-3xl font-bold tracking-tight text-foreground"
           >
-            Früher Zugang sichern
+            Unverbindlich anfragen
           </h2>
           <p className="mb-8 text-center text-muted-foreground">
-            Tragen Sie sich jetzt ein und gehören Sie zu den Ersten, die FörderPilot nutzen.
+            Wir prüfen, ob Foerderis zu Ihrem Unternehmen passt — und melden uns innerhalb von
+            zwei Werktagen.
           </p>
           <WaitlistForm />
         </div>
@@ -92,7 +211,7 @@ export default function Home() {
       <footer className="border-t border-border px-4 py-8">
         <div className="mx-auto flex max-w-5xl flex-col items-center gap-3 text-center sm:flex-row sm:justify-between sm:text-left">
           <p className="text-sm text-muted-foreground">
-            © {new Date().getFullYear()} FörderPilot. Alle Rechte vorbehalten.
+            © {new Date().getFullYear()} Foerderis. Alle Rechte vorbehalten.
           </p>
           <nav aria-label="Footer-Navigation">
             <a

--- a/apps/web/components/waitlist-form.tsx
+++ b/apps/web/components/waitlist-form.tsx
@@ -19,7 +19,7 @@ export function WaitlistForm() {
           Vielen Dank! Sie stehen auf der Liste.
         </p>
         <p className="text-sm text-muted-foreground">
-          Wir melden uns, sobald FörderPilot startklar ist.
+          Wir melden uns innerhalb von zwei Werktagen bei Ihnen.
         </p>
       </div>
     );

--- a/apps/web/e2e/landing.spec.ts
+++ b/apps/web/e2e/landing.spec.ts
@@ -12,16 +12,27 @@ test.describe("Landing Page — Smoke Tests", () => {
 
   test("hero section is visible", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: /Fördermittel/i, level: 1 })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Warteliste/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /bezahlt/i, level: 1 })).toBeVisible();
+    await expect(page.getByRole("link", { name: /anfragen/i })).toBeVisible();
   });
 
-  test("value proposition section is visible", async ({ page }) => {
+  test("how it works section is visible", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: /FörderPilot für Sie/i })).toBeVisible();
-    await expect(page.getByText("Automatische Förderrecherche")).toBeVisible();
-    await expect(page.getByText("KI-gestützte Antragsvorbereitung")).toBeVisible();
-    await expect(page.getByText("Integrierter Compliance-Check")).toBeVisible();
+    await expect(page.getByRole("heading", { name: /So funktioniert es/i })).toBeVisible();
+    await expect(page.getByText("Wir lernen Ihr Unternehmen kennen")).toBeVisible();
+    await expect(page.getByText(/KI-Team arbeitet rund um die Uhr/i)).toBeVisible();
+    await expect(page.getByText(/nur bei Bewilligung/i)).toBeVisible();
+  });
+
+  test("pricing section is visible", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: /10 %/i })).toBeVisible();
+  });
+
+  test("audience section is visible", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: /Für wen wir arbeiten/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Was wir nicht sind/i })).toBeVisible();
   });
 
   test("footer with Impressum link is visible", async ({ page }) => {
@@ -36,13 +47,13 @@ test.describe("Landing Page — Smoke Tests", () => {
   });
 });
 
-test.describe("Waitlist Form", () => {
+test.describe("Kontakt Form", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/#warteliste");
+    await page.goto("/#kontakt");
   });
 
   test("form is visible", async ({ page }) => {
-    await expect(page.getByRole("heading", { name: /Früher Zugang/i })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Unverbindlich anfragen/i })).toBeVisible();
     await expect(page.getByLabel(/E-Mail/i)).toBeVisible();
     await expect(page.getByLabel(/Firmenname/i)).toBeVisible();
     await expect(page.getByRole("button", { name: /vormerken/i })).toBeVisible();
@@ -76,7 +87,7 @@ test.describe("Responsive Layout", () => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
 
-    await expect(page.getByRole("heading", { name: /Fördermittel/i, level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /bezahlt/i, level: 1 })).toBeVisible();
     await expect(page.getByLabel(/E-Mail/i)).toBeVisible();
     await expect(page.getByLabel(/Firmenname/i)).toBeVisible();
     await expect(page.getByRole("link", { name: "Impressum" })).toBeVisible();
@@ -86,7 +97,7 @@ test.describe("Responsive Layout", () => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("/");
 
-    await expect(page.getByRole("heading", { name: /Fördermittel/i, level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /bezahlt/i, level: 1 })).toBeVisible();
     await expect(page.getByLabel(/E-Mail/i)).toBeVisible();
     await expect(page.getByLabel(/Firmenname/i)).toBeVisible();
     await expect(page.getByRole("link", { name: "Impressum" })).toBeVisible();


### PR DESCRIPTION
## Was geändert wurde

- **Hero:** Hauptbotschaft "Wir werden nur bezahlt, wenn Sie gefördert werden" — weg von "Nie wieder Fördermittel verpassen"
- **Wie es funktioniert:** 3-Schritte-Sektion statt Value-Prop-Cards (Erfolgshonorarprozess sichtbar machen)
- **Kosten:** 10%-Sektion prominent mit Bulletliste der Risikoschutz-Garantien
- **Für wen / Was wir nicht sind:** Klare Abgrenzung von SaaS, Chatbot, Startups
- **Form-Anker:** `#warteliste` → `#kontakt` (neutrale, seriösere Formulierung)
- **Meta:** Titel/Description auf Foerderis-Positionierung aktualisiert
- **E2E-Tests:** Alle Test-Strings auf neue Copy angepasst

## Bezieht sich auf

FRDAA-25 Landingpage Copy v2: Foerderis Positioning

## Pflichtlektüre

Brand-Brief: docs/BRAND.md
