### PR TITLE
feat(web): Waitlist → E-Mail-Notification + Paperclip Lead Task [FRDAA-32]

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,33 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/foerderis
 # Auth (Better Auth)
 BETTER_AUTH_SECRET=your-secret-here
 BETTER_AUTH_URL=http://localhost:3000
+
+# Resend — ausgehende E-Mails (Waitlist-Confirmation + Internal Alerts)
+# Kostenlos bis 3.000 Mails/Monat — https://resend.com
+# Domain foerderis.de muss via SPF/DKIM/Return-Path in Hostinger-DNS verifiziert sein
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxx
+
+# Interne Benachrichtigungs-E-Mail (Default: felix@foerderis.de)
+NOTIFICATION_EMAIL=felix@foerderis.de
+
+# Paperclip — Lead-Task-Erstellung bei Waitlist-Eintrag
+PAPERCLIP_API_URL=https://felixgaber-hostinger.com/api
+PAPERCLIP_COMPANY_ID=a2365516-5c35-4933-86fe-5f03c609e570
+PAPERCLIP_CEO_AGENT_ID=a396757c-4fbe-49f7-8cfb-49050d72f356
+# System-Token: im Paperclip-Dashboard unter API Keys erstellen (nicht ins Repo committen)
+PAPERCLIP_SYSTEM_TOKEN=pc_sys_xxxxxxxxxxxxxxxx
 ```
 
 Für Produktion werden die Werte im Vercel-Projekt gesetzt.
+
+> **Hinweis Resend-DNS:** Für `kontakt@foerderis.de` als Absender müssen in der Hostinger-DNS
+> folgende Records gesetzt sein (Werte aus dem Resend-Dashboard):
+> - `SPF` (TXT auf `foerderis.de`)
+> - `DKIM` (TXT auf `resend._domainkey.foerderis.de`)
+> - `Return-Path` (CNAME auf `bounces.resend.com`)
+>
+> **Hinweis PAPERCLIP_SYSTEM_TOKEN:** Diesen Token im Paperclip-Dashboard als Service-Account-Token erstellen.
+> Er darf ausschließlich im Vercel-Projekt gesetzt werden — niemals ins Git-Repository.
 
 ### Verfügbare Scripts
 

--- a/apps/web/app/actions/__tests__/waitlist.notifications.test.ts
+++ b/apps/web/app/actions/__tests__/waitlist.notifications.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — must be hoisted before any imports of the module under
+// test.  We mock the two external I/O surfaces: Resend and fetch.
+// ---------------------------------------------------------------------------
+
+// Mock `resend` package
+vi.mock("resend", () => {
+  const mockSend = vi.fn().mockResolvedValue({ data: { id: "email-id" }, error: null });
+  return {
+    Resend: vi.fn().mockImplementation(() => ({
+      emails: { send: mockSend },
+    })),
+    __mockSend: mockSend,
+  };
+});
+
+// Mock `@foerderis/db` — avoids DATABASE_URL requirement
+vi.mock("@foerderis/db", () => ({
+  db: {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+  waitlist: {},
+}));
+
+// Mock `@foerderis/shared` — minimal schema that passes
+vi.mock("@foerderis/shared", () => ({
+  waitlistFormSchema: {
+    safeParse: vi.fn((data) => ({
+      success: true,
+      data: { email: data.email, companyName: data.companyName },
+    })),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import the module under test AFTER the mocks are hoisted
+// ---------------------------------------------------------------------------
+import { submitWaitlist } from "../waitlist";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFormData(email: string, companyName: string): FormData {
+  const fd = new FormData();
+  fd.set("email", email);
+  fd.set("companyName", companyName);
+  return fd;
+}
+
+function mockFetch(ok: boolean, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    text: () => Promise.resolve(ok ? "OK" : "Internal Server Error"),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("submitWaitlist — notification side-effects", () => {
+  const idle = { status: "idle" as const };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset env vars
+    delete process.env.RESEND_API_KEY;
+    delete process.env.PAPERCLIP_API_URL;
+    delete process.env.PAPERCLIP_COMPANY_ID;
+    delete process.env.PAPERCLIP_CEO_AGENT_ID;
+    delete process.env.PAPERCLIP_SYSTEM_TOKEN;
+    delete process.env.NOTIFICATION_EMAIL;
+  });
+
+  it("returns success even when RESEND_API_KEY and Paperclip vars are absent", async () => {
+    const result = await submitWaitlist(idle, makeFormData("lead@acme.de", "Acme GmbH"));
+    expect(result).toEqual({ status: "success" });
+  });
+
+  it("sends two emails when RESEND_API_KEY is set", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+
+    const { Resend } = await import("resend");
+    const instance = new (Resend as any)();
+    const sendSpy = instance.emails.send;
+
+    const result = await submitWaitlist(idle, makeFormData("lead@acme.de", "Acme GmbH"));
+    expect(result).toEqual({ status: "success" });
+    // confirmation + internal alert
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends confirmation email to the lead's address", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+
+    const { Resend } = await import("resend");
+    const instance = new (Resend as any)();
+    const sendSpy = instance.emails.send;
+
+    await submitWaitlist(idle, makeFormData("ceo@startup.de", "Startup AG"));
+
+    const calls = sendSpy.mock.calls.map((c: any) => c[0]);
+    const confirmCall = calls.find((c: any) => c.to === "ceo@startup.de");
+    expect(confirmCall).toBeDefined();
+    expect(confirmCall.subject).toContain("Danke");
+  });
+
+  it("sends internal alert to felix@foerderis.de by default", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+
+    const { Resend } = await import("resend");
+    const instance = new (Resend as any)();
+    const sendSpy = instance.emails.send;
+
+    await submitWaitlist(idle, makeFormData("lead@corp.de", "Corp KG"));
+
+    const calls = sendSpy.mock.calls.map((c: any) => c[0]);
+    const alertCall = calls.find((c: any) => c.to === "felix@foerderis.de");
+    expect(alertCall).toBeDefined();
+    expect(alertCall.subject).toContain("Corp KG");
+  });
+
+  it("sends internal alert to NOTIFICATION_EMAIL env var when set", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    process.env.NOTIFICATION_EMAIL = "alerts@example.com";
+
+    const { Resend } = await import("resend");
+    const instance = new (Resend as any)();
+    const sendSpy = instance.emails.send;
+
+    await submitWaitlist(idle, makeFormData("lead@corp.de", "Corp KG"));
+
+    const calls = sendSpy.mock.calls.map((c: any) => c[0]);
+    const alertCall = calls.find((c: any) => c.to === "alerts@example.com");
+    expect(alertCall).toBeDefined();
+  });
+
+  it("creates a Paperclip task when all env vars are set", async () => {
+    process.env.PAPERCLIP_API_URL = "https://api.example.com";
+    process.env.PAPERCLIP_COMPANY_ID = "company-123";
+    process.env.PAPERCLIP_CEO_AGENT_ID = "agent-ceo-456";
+    process.env.PAPERCLIP_SYSTEM_TOKEN = "sys_token_789";
+
+    global.fetch = mockFetch(true);
+
+    const result = await submitWaitlist(idle, makeFormData("lead@acme.de", "Acme GmbH"));
+    expect(result).toEqual({ status: "success" });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.example.com/api/companies/company-123/issues",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer sys_token_789",
+        }),
+      }),
+    );
+
+    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(body.title).toBe("Lead qualifizieren: Acme GmbH");
+    expect(body.assigneeAgentId).toBe("agent-ceo-456");
+    expect(body.description).toContain("lead@acme.de");
+  });
+
+  it("still returns success when Paperclip API call fails", async () => {
+    process.env.PAPERCLIP_API_URL = "https://api.example.com";
+    process.env.PAPERCLIP_COMPANY_ID = "company-123";
+    process.env.PAPERCLIP_CEO_AGENT_ID = "agent-ceo-456";
+    process.env.PAPERCLIP_SYSTEM_TOKEN = "sys_token_789";
+
+    global.fetch = mockFetch(false, 500);
+
+    const result = await submitWaitlist(idle, makeFormData("lead@acme.de", "Acme GmbH"));
+    expect(result).toEqual({ status: "success" });
+  });
+
+  it("returns success when email send fails (lead already in DB)", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+
+    const { Resend } = await import("resend");
+    const instance = new (Resend as any)();
+    instance.emails.send.mockRejectedValue(new Error("Network error"));
+
+    const result = await submitWaitlist(idle, makeFormData("lead@acme.de", "Acme GmbH"));
+    expect(result).toEqual({ status: "success" });
+  });
+});
+
+describe("submitWaitlist — DB layer", () => {
+  const idle = { status: "idle" as const };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.RESEND_API_KEY;
+  });
+
+  it("returns error with duplicate message on unique constraint violation", async () => {
+    const { waitlistFormSchema } = await import("@foerderis/shared");
+    (waitlistFormSchema.safeParse as any).mockReturnValueOnce({
+      success: true,
+      data: { email: "dup@acme.de", companyName: "Acme GmbH" },
+    });
+
+    const { db } = await import("@foerderis/db");
+    (db.insert as any).mockReturnValueOnce({
+      values: vi.fn().mockRejectedValueOnce(new Error("unique constraint")),
+    });
+
+    const result = await submitWaitlist(idle, makeFormData("dup@acme.de", "Acme GmbH"));
+    expect(result).toEqual({
+      status: "error",
+      message: "Diese E-Mail-Adresse ist bereits registriert.",
+    });
+  });
+
+  it("returns error with generic message on unexpected DB error", async () => {
+    const { waitlistFormSchema } = await import("@foerderis/shared");
+    (waitlistFormSchema.safeParse as any).mockReturnValueOnce({
+      success: true,
+      data: { email: "x@acme.de", companyName: "Acme" },
+    });
+
+    const { db } = await import("@foerderis/db");
+    (db.insert as any).mockReturnValueOnce({
+      values: vi.fn().mockRejectedValueOnce(new Error("connection refused")),
+    });
+
+    const result = await submitWaitlist(idle, makeFormData("x@acme.de", "Acme"));
+    expect(result).toEqual({
+      status: "error",
+      message: "Ein Fehler ist aufgetreten. Bitte versuche es später erneut.",
+    });
+  });
+
+  it("returns validation error when schema parse fails", async () => {
+    const { waitlistFormSchema } = await import("@foerderis/shared");
+    (waitlistFormSchema.safeParse as any).mockReturnValueOnce({
+      success: false,
+      error: { errors: [{ message: "Ungültige E-Mail-Adresse." }] },
+    });
+
+    const result = await submitWaitlist(idle, makeFormData("not-an-email", "Acme"));
+    expect(result).toEqual({
+      status: "error",
+      message: "Ungültige E-Mail-Adresse.",
+    });
+  });
+});

--- a/apps/web/app/actions/waitlist.ts
+++ b/apps/web/app/actions/waitlist.ts
@@ -1,15 +1,117 @@
 "use server";
 
-import { waitlistFormSchema } from "@foerderpilot/shared";
+import { waitlistFormSchema } from "@foerderis/shared";
+import { Resend } from "resend";
 
 export type WaitlistState =
   | { status: "idle" }
   | { status: "success" }
   | { status: "error"; message: string };
 
+// ---------------------------------------------------------------------------
+// Side-effect helpers — each can fail independently without losing the lead
+// ---------------------------------------------------------------------------
+
+async function sendLeadConfirmationEmail(
+  resend: Resend,
+  email: string,
+  companyName: string,
+): Promise<void> {
+  await resend.emails.send({
+    from: "Foerderis <kontakt@foerderis.de>",
+    to: email,
+    subject: "Danke für Ihr Interesse an Foerderis",
+    html: `
+<p>Guten Tag,</p>
+<p>vielen Dank für Ihre Anfrage. Wir haben Ihre Anmeldung für <strong>${companyName}</strong> erhalten.</p>
+<p>Unser Team meldet sich innerhalb von 2 Werktagen bei Ihnen.</p>
+<p>Bei Rückfragen erreichen Sie uns jederzeit unter <a href="mailto:kontakt@foerderis.de">kontakt@foerderis.de</a>.</p>
+<p>Mit freundlichen Grüßen<br/>Das Foerderis-Team</p>
+    `.trim(),
+  });
+}
+
+async function sendInternalAlertEmail(
+  resend: Resend,
+  email: string,
+  companyName: string,
+): Promise<void> {
+  const notificationEmail =
+    process.env.NOTIFICATION_EMAIL ?? "felix@foerderis.de";
+  await resend.emails.send({
+    from: "Foerderis System <kontakt@foerderis.de>",
+    to: notificationEmail,
+    subject: `Neuer Waitlist-Lead: ${companyName}`,
+    html: `
+<p><strong>Neuer Lead auf der Waitlist</strong></p>
+<ul>
+  <li><strong>Firma:</strong> ${companyName}</li>
+  <li><strong>E-Mail:</strong> ${email}</li>
+  <li><strong>Timestamp:</strong> ${new Date().toISOString()}</li>
+</ul>
+    `.trim(),
+  });
+}
+
+async function createPaperclipLeadTask(
+  email: string,
+  companyName: string,
+): Promise<void> {
+  const apiUrl = process.env.PAPERCLIP_API_URL;
+  const companyId = process.env.PAPERCLIP_COMPANY_ID;
+  const ceoAgentId = process.env.PAPERCLIP_CEO_AGENT_ID;
+  const systemToken = process.env.PAPERCLIP_SYSTEM_TOKEN;
+
+  if (!apiUrl || !companyId || !ceoAgentId || !systemToken) {
+    console.warn(
+      "[waitlist] Paperclip env vars not configured — skipping task creation",
+    );
+    return;
+  }
+
+  const body = {
+    title: `Lead qualifizieren: ${companyName}`,
+    description: [
+      "## Lead-Daten",
+      "",
+      `- **Firma:** ${companyName}`,
+      `- **E-Mail:** ${email}`,
+      `- **Eingetragen am:** ${new Date().toISOString()}`,
+      "",
+      "## Aufgabe",
+      "",
+      "Recherchiere das Unternehmen und entwirf einen passenden Ansatz für die Erstansprache.",
+      "Berücksichtige Unternehmensgröße, Branche und mögliche Förderprogramme.",
+    ].join("\n"),
+    status: "todo",
+    priority: "high",
+    assigneeAgentId: ceoAgentId,
+    companyId,
+  };
+
+  const res = await fetch(`${apiUrl}/api/companies/${companyId}/issues`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${systemToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Paperclip API responded ${res.status}: ${await res.text()}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server action
+// ---------------------------------------------------------------------------
+
 export async function submitWaitlist(
   _prevState: WaitlistState,
-  formData: FormData
+  formData: FormData,
 ): Promise<WaitlistState> {
   const raw = {
     email: formData.get("email"),
@@ -24,11 +126,11 @@ export async function submitWaitlist(
     };
   }
 
+  // 1. Persist lead — must succeed; nothing else matters if it fails.
   try {
     // Dynamic import keeps the module-level DATABASE_URL check out of build time
-    const { db, waitlist } = await import("@foerderpilot/db");
+    const { db, waitlist } = await import("@foerderis/db");
     await db.insert(waitlist).values(parsed.data);
-    return { status: "success" };
   } catch (err) {
     const msg = err instanceof Error ? err.message : "";
     if (msg.includes("unique") || msg.includes("duplicate")) {
@@ -42,4 +144,42 @@ export async function submitWaitlist(
       message: "Ein Fehler ist aufgetreten. Bitte versuche es später erneut.",
     };
   }
+
+  const { email, companyName } = parsed.data;
+
+  // 2. Fire side-effects in parallel, independently — lead is never lost.
+  const resendApiKey = process.env.RESEND_API_KEY;
+  const resend = resendApiKey ? new Resend(resendApiKey) : null;
+
+  const [emailConfirmResult, emailAlertResult, paperclipResult] =
+    await Promise.allSettled([
+      resend
+        ? sendLeadConfirmationEmail(resend, email, companyName)
+        : Promise.reject(new Error("RESEND_API_KEY not configured")),
+      resend
+        ? sendInternalAlertEmail(resend, email, companyName)
+        : Promise.reject(new Error("RESEND_API_KEY not configured")),
+      createPaperclipLeadTask(email, companyName),
+    ]);
+
+  if (emailConfirmResult.status === "rejected") {
+    console.error(
+      "[waitlist] Lead confirmation email failed:",
+      emailConfirmResult.reason,
+    );
+  }
+  if (emailAlertResult.status === "rejected") {
+    console.error(
+      "[waitlist] Internal alert email failed:",
+      emailAlertResult.reason,
+    );
+  }
+  if (paperclipResult.status === "rejected") {
+    console.error(
+      "[waitlist] Paperclip task creation failed:",
+      paperclipResult.reason,
+    );
+  }
+
+  return { status: "success" };
 }

--- a/apps/web/app/impressum/page.tsx
+++ b/apps/web/app/impressum/page.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@foerderpilot/ui";
+import { Button } from "@foerderis/ui";
 import type { Metadata } from "next";
 import Link from "next/link";
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,6 @@
 import { WaitlistForm } from "@/components/waitlist-form";
-import { Button } from "@foerderpilot/ui";
-import { Card, CardContent } from "@foerderpilot/ui";
+import { Button } from "@foerderis/ui";
+import { Card, CardContent } from "@foerderis/ui";
 import { Clock, FileText, ShieldCheck } from "lucide-react";
 
 const HOW_IT_WORKS = [

--- a/apps/web/components/waitlist-form.tsx
+++ b/apps/web/components/waitlist-form.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { type WaitlistState, submitWaitlist } from "@/app/actions/waitlist";
-import { Button } from "@foerderpilot/ui";
-import { Input } from "@foerderpilot/ui";
+import { Button } from "@foerderis/ui";
+import { Input } from "@foerderis/ui";
 import { AlertCircle, CheckCircle, Loader2 } from "lucide-react";
 import { useActionState } from "react";
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@foerderpilot/ui", "@foerderpilot/db", "@foerderpilot/shared"],
+  transpilePackages: ["@foerderis/ui", "@foerderis/db", "@foerderis/shared"],
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@foerderpilot/web",
+  "name": "@foerderis/web",
   "version": "0.0.0",
   "private": true,
   "scripts": {
@@ -10,12 +10,15 @@
     "typecheck": "tsc --noEmit",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
-    "e2e:report": "playwright show-report"
+    "e2e:report": "playwright show-report",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "@foerderpilot/db": "workspace:*",
-    "@foerderpilot/shared": "workspace:*",
-    "@foerderpilot/ui": "workspace:*",
+    "@foerderis/db": "workspace:*",
+    "@foerderis/shared": "workspace:*",
+    "@foerderis/ui": "workspace:*",
+    "resend": "^4.5.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",
@@ -32,6 +35,8 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "tailwindcss": "^4.2.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.1",
+    "@vitest/coverage-v8": "^3.1.1"
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["**/__tests__/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- **Confirmation email** to the lead (via Resend, from `kontakt@foerderis.de`) fires immediately after DB insert
- **Internal alert email** to `NOTIFICATION_EMAIL` (default `felix@foerderis.de`) with company name, email, and timestamp
- **Paperclip task** `Lead qualifizieren: {firma}` created via Paperclip API, assigned to CEO agent
- All three side-effects use `Promise.allSettled` — a downstream failure never loses the lead
- Also fixes `@foerderpilot/*` → `@foerderis/*` imports in `apps/web` (follow-up from FRDAA-22/23)

## New env vars required (Vercel)

| Variable | Purpose |
|---|---|
| `RESEND_API_KEY` | Resend API key for outbound email |
| `NOTIFICATION_EMAIL` | Internal alert recipient (default: `felix@foerderis.de`) |
| `PAPERCLIP_API_URL` | Paperclip API base URL |
| `PAPERCLIP_COMPANY_ID` | Paperclip company ID |
| `PAPERCLIP_CEO_AGENT_ID` | CEO agent ID to assign lead tasks |
| `PAPERCLIP_SYSTEM_TOKEN` | Service-account token for system → Paperclip calls |

**DNS for Resend:** SPF, DKIM, Return-Path records must be set in Hostinger DNS for `foerderis.de` (see README).

## Test plan

- [ ] `pnpm --filter @foerderis/web test` — 10 Vitest unit tests pass
- [ ] Deploy preview: submit waitlist form, confirm no build errors
- [ ] With real `RESEND_API_KEY`: verify lead confirmation + internal alert emails arrive
- [ ] With real Paperclip token: verify CEO agent receives a `Lead qualifizieren: {firma}` task
- [ ] Submit duplicate email: confirm `"bereits registriert"` error still returns
- [ ] Kill Resend / Paperclip endpoint mid-flight: confirm form still returns success

🤖 Generated with [Claude Code](https://claude.com/claude-code)