### PR TITLE
feat(web): daily digest route — Tagesübersicht für Felix [FRDAA-35]

### DIFF
--- a/apps/web/app/api/internal/daily-digest/__tests__/daily-digest.test.ts
+++ b/apps/web/app/api/internal/daily-digest/__tests__/daily-digest.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted before module imports
+// ---------------------------------------------------------------------------
+
+vi.mock("resend", () => {
+  const mockSend = vi
+    .fn()
+    .mockResolvedValue({ data: { id: "email-id" }, error: null });
+  return {
+    Resend: vi.fn().mockImplementation(() => ({
+      emails: { send: mockSend },
+    })),
+    __mockSend: mockSend,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Imports
+// ---------------------------------------------------------------------------
+
+import * as resendModule from "resend";
+import {
+  buildDigestHtml,
+  fetchIssues,
+  type PaperclipIssue,
+} from "../route.js";
+import { POST } from "../route.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockSend = (resendModule as unknown as { __mockSend: ReturnType<typeof vi.fn> })
+  .__mockSend;
+
+function makeIssue(overrides: Partial<PaperclipIssue> = {}): PaperclipIssue {
+  return {
+    id: "issue-id",
+    identifier: "FRDAA-99",
+    title: "Test Issue",
+    description: "A test issue description.",
+    status: "done",
+    completedAt: new Date().toISOString(),
+    priority: "medium",
+    ...overrides,
+  };
+}
+
+function makeRequest(body = {}, secret?: string): Request {
+  return new Request("http://localhost/api/internal/daily-digest", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(secret ? { Authorization: `Bearer ${secret}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const baseEnv = {
+  RESEND_API_KEY: "re_test",
+  PAPERCLIP_API_URL: "http://paperclip.test",
+  PAPERCLIP_COMPANY_ID: "company-id",
+  PAPERCLIP_SYSTEM_TOKEN: "system-token",
+  PAPERCLIP_UI_URL: "https://app.foerderis.de",
+};
+
+// ---------------------------------------------------------------------------
+// Unit: buildDigestHtml
+// ---------------------------------------------------------------------------
+
+describe("buildDigestHtml", () => {
+  const base = "https://app.foerderis.de";
+
+  it("includes all three sections", () => {
+    const done = [makeIssue({ identifier: "FRDAA-1", title: "Done one" })];
+    const inProgress = [
+      makeIssue({ identifier: "FRDAA-2", title: "In progress", status: "in_progress", completedAt: null }),
+    ];
+    const approval = [
+      makeIssue({ identifier: "FRDAA-3", title: "Needs review", status: "in_review", completedAt: null }),
+    ];
+
+    const html = buildDigestHtml(done, inProgress, approval, base);
+    expect(html).toContain("FRDAA-1");
+    expect(html).toContain("FRDAA-2");
+    expect(html).toContain("FRDAA-3");
+    expect(html).toContain("Abgeschlossen");
+    expect(html).toContain("Im Flow");
+    expect(html).toContain("Wartet auf Approval");
+  });
+
+  it("shows empty-state messages when lists are empty", () => {
+    const html = buildDigestHtml([], [], [], base);
+    expect(html).toContain("Keine Tasks abgeschlossen");
+    expect(html).toContain("Keine laufenden Tasks");
+    expect(html).toContain("Keine offenen Approval-Anfragen");
+  });
+
+  it("generates correct issue links using baseUrl", () => {
+    const done = [makeIssue({ identifier: "FRDAA-42" })];
+    const html = buildDigestHtml(done, [], [], base);
+    expect(html).toContain("https://app.foerderis.de/FRDAA/issues/FRDAA-42");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: fetchIssues
+// ---------------------------------------------------------------------------
+
+describe("fetchIssues", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("calls the correct URL and returns parsed issues", async () => {
+    const issues = [makeIssue()];
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(issues), { status: 200 }),
+    );
+
+    const result = await fetchIssues(
+      "http://paperclip.test",
+      "company-id",
+      "token",
+      { status: "done" },
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://paperclip.test/api/companies/company-id/issues?status=done",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+    expect(result).toEqual(issues);
+  });
+
+  it("throws when Paperclip returns a non-OK status", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response("", { status: 500 }),
+    );
+    await expect(
+      fetchIssues("http://paperclip.test", "c", "t", { status: "done" }),
+    ).rejects.toThrow("Paperclip query failed: 500");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: POST handler
+// ---------------------------------------------------------------------------
+
+describe("POST /api/internal/daily-digest", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+    mockSend.mockClear();
+    // Clear env overrides
+    for (const key of Object.keys(baseEnv)) {
+      delete process.env[key];
+    }
+    delete process.env.INTERNAL_WEBHOOK_SECRET;
+  });
+
+  function applyEnv(overrides: Partial<typeof baseEnv> = {}) {
+    const env = { ...baseEnv, ...overrides };
+    for (const [k, v] of Object.entries(env)) {
+      process.env[k] = v;
+    }
+  }
+
+  function mockPaperclipFetch(
+    done: PaperclipIssue[],
+    inProgress: PaperclipIssue[],
+    approval: PaperclipIssue[],
+  ) {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify(done), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(inProgress), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(approval), { status: 200 }));
+  }
+
+  it("returns 503 when required env vars are missing", async () => {
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.missing).toContain("RESEND_API_KEY");
+  });
+
+  it("returns 401 when secret is set but header is wrong", async () => {
+    applyEnv();
+    process.env.INTERNAL_WEBHOOK_SECRET = "secret123";
+
+    const res = await POST(makeRequest({}, "wrong-secret"));
+    expect(res.status).toBe(401);
+  });
+
+  it("sends digest and returns stats", async () => {
+    applyEnv();
+
+    const now = new Date().toISOString();
+    const yesterday = new Date(Date.now() - 30 * 60 * 1000).toISOString(); // 30 min ago — within 24h
+    const oldDone = makeIssue({ identifier: "FRDAA-10", completedAt: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString() }); // 25h ago — outside 24h
+
+    const doneIssues = [
+      makeIssue({ identifier: "FRDAA-11", completedAt: yesterday }),
+      oldDone,
+    ];
+    const inProgressIssues = [
+      makeIssue({ identifier: "FRDAA-20", status: "in_progress", completedAt: null }),
+    ];
+    const approvalIssues = [
+      makeIssue({ identifier: "FRDAA-30", status: "in_review", completedAt: null }),
+    ];
+
+    mockPaperclipFetch(doneIssues, inProgressIssues, approvalIssues);
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.sent).toBe(true);
+    expect(body.stats.done).toBe(1);       // only the recent one
+    expect(body.stats.inProgress).toBe(1);
+    expect(body.stats.needsApproval).toBe(1);
+
+    expect(mockSend).toHaveBeenCalledOnce();
+    const callArgs = mockSend.mock.calls[0][0] as { subject: string; html: string; to: string };
+    expect(callArgs.to).toBe("felix@foerderis.de");
+    expect(callArgs.subject).toMatch(/Tagesübersicht/);
+    expect(callArgs.html).toContain("FRDAA-11");
+    expect(callArgs.html).not.toContain("FRDAA-10"); // old done — filtered out
+  });
+
+  it("passes auth when secret matches", async () => {
+    applyEnv();
+    process.env.INTERNAL_WEBHOOK_SECRET = "secret123";
+
+    mockPaperclipFetch([], [], []);
+
+    const res = await POST(makeRequest({}, "secret123"));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when Paperclip fetch throws", async () => {
+    applyEnv();
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("network error"));
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/app/api/internal/daily-digest/route.ts
+++ b/apps/web/app/api/internal/daily-digest/route.ts
@@ -1,0 +1,180 @@
+import { NextResponse } from "next/server";
+import { Resend } from "resend";
+
+// ---------------------------------------------------------------------------
+// Internal webhook — called by the DevOpsEngineer Paperclip agent when the
+// "Daily Digest" routine fires (daily at 08:00 Europe/Berlin).
+// Protected by INTERNAL_WEBHOOK_SECRET when set.
+//
+// Workflow:
+//  1. Fetch issues completed in the last 24 h (status=done)
+//  2. Fetch all currently in_progress issues
+//  3. Fetch in_review issues tagged `needs-approval` (awaiting Felix approval)
+//  4. Compose an HTML digest email and send via Resend to felix@foerderis.de
+// ---------------------------------------------------------------------------
+
+const NEEDS_APPROVAL_LABEL_ID = "d730a759-2ab7-4646-93fb-6650642274f6";
+const DIGEST_RECIPIENT = "felix@foerderis.de";
+
+export interface PaperclipIssue {
+  id: string;
+  identifier: string;
+  title: string;
+  description: string | null;
+  status: string;
+  completedAt: string | null;
+  priority: string;
+}
+
+export async function fetchIssues(
+  apiUrl: string,
+  companyId: string,
+  token: string,
+  params: Record<string, string>,
+): Promise<PaperclipIssue[]> {
+  const query = new URLSearchParams(params).toString();
+  const res = await fetch(
+    `${apiUrl}/api/companies/${companyId}/issues?${query}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok) {
+    throw new Error(`Paperclip query failed: ${res.status} (${query})`);
+  }
+  return res.json() as Promise<PaperclipIssue[]>;
+}
+
+export function buildDigestHtml(
+  done: PaperclipIssue[],
+  inProgress: PaperclipIssue[],
+  needsApproval: PaperclipIssue[],
+  baseUrl: string,
+): string {
+  const issueUrl = (issue: PaperclipIssue) =>
+    `${baseUrl}/FRDAA/issues/${issue.identifier}`;
+
+  const issueRow = (issue: PaperclipIssue) =>
+    `<li><a href="${issueUrl(issue)}">${issue.identifier}</a> — ${issue.title}</li>`;
+
+  const section = (
+    heading: string,
+    items: PaperclipIssue[],
+    emptyMsg: string,
+  ) => `
+<h2 style="color:#1a1a1a;border-bottom:2px solid #e5e7eb;padding-bottom:8px;margin-top:28px;">${heading}</h2>
+${items.length > 0 ? `<ul style="line-height:1.8;">${items.map(issueRow).join("")}</ul>` : `<p style="color:#6b7280;font-style:italic;">${emptyMsg}</p>`}`;
+
+  const dateStr = new Date().toLocaleDateString("de-DE", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return `<!DOCTYPE html>
+<html lang="de">
+<head><meta charset="UTF-8"/></head>
+<body style="font-family:sans-serif;max-width:620px;margin:0 auto;padding:24px;color:#374151;">
+  <h1 style="color:#f59e0b;margin-bottom:4px;">Foerderis Tagesübersicht</h1>
+  <p style="color:#6b7280;margin-top:0;">${dateStr}</p>
+  ${section("✅ Abgeschlossen (letzte 24 h)", done, "Keine Tasks abgeschlossen.")}
+  ${section("⚙️ Im Flow", inProgress, "Keine laufenden Tasks.")}
+  ${section("🔔 Wartet auf Approval", needsApproval, "Keine offenen Approval-Anfragen.")}
+  <hr style="margin-top:32px;border:none;border-top:1px solid #e5e7eb;"/>
+  <p style="color:#9ca3af;font-size:0.8em;margin-top:12px;">
+    Foerderis Daily Digest · automatisch generiert · <a href="${baseUrl}">Paperclip öffnen</a>
+  </p>
+</body>
+</html>`;
+}
+
+export async function POST(request: Request) {
+  // Optional bearer-token auth
+  const secret = process.env.INTERNAL_WEBHOOK_SECRET;
+  if (secret) {
+    const auth = request.headers.get("Authorization");
+    if (auth !== `Bearer ${secret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  const resendApiKey = process.env.RESEND_API_KEY;
+  const paperclipApiUrl = process.env.PAPERCLIP_API_URL;
+  const paperclipCompanyId = process.env.PAPERCLIP_COMPANY_ID;
+  const paperclipSystemToken = process.env.PAPERCLIP_SYSTEM_TOKEN;
+  const paperclipUiUrl =
+    process.env.PAPERCLIP_UI_URL ?? "https://paperclip.ing";
+
+  if (
+    !resendApiKey ||
+    !paperclipApiUrl ||
+    !paperclipCompanyId ||
+    !paperclipSystemToken
+  ) {
+    return NextResponse.json(
+      {
+        error: "Missing required env vars",
+        missing: [
+          !resendApiKey && "RESEND_API_KEY",
+          !paperclipApiUrl && "PAPERCLIP_API_URL",
+          !paperclipCompanyId && "PAPERCLIP_COMPANY_ID",
+          !paperclipSystemToken && "PAPERCLIP_SYSTEM_TOKEN",
+        ].filter(Boolean),
+      },
+      { status: 503 },
+    );
+  }
+
+  const resend = new Resend(resendApiKey);
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  try {
+    // Fetch all three datasets in parallel
+    const [allDone, inProgress, needsApproval] = await Promise.all([
+      fetchIssues(paperclipApiUrl, paperclipCompanyId, paperclipSystemToken, {
+        status: "done",
+      }),
+      fetchIssues(paperclipApiUrl, paperclipCompanyId, paperclipSystemToken, {
+        status: "in_progress",
+      }),
+      fetchIssues(paperclipApiUrl, paperclipCompanyId, paperclipSystemToken, {
+        status: "in_review",
+        labelId: NEEDS_APPROVAL_LABEL_ID,
+      }),
+    ]);
+
+    // Keep only issues completed within the last 24 h
+    const recentlyDone = allDone.filter(
+      (i) => i.completedAt != null && i.completedAt >= cutoff,
+    );
+
+    const html = buildDigestHtml(
+      recentlyDone,
+      inProgress,
+      needsApproval,
+      paperclipUiUrl,
+    );
+
+    const dateLabel = new Date().toLocaleDateString("de-DE");
+    await resend.emails.send({
+      from: "Foerderis <kontakt@foerderis.de>",
+      to: DIGEST_RECIPIENT,
+      subject: `[Foerderis] Tagesübersicht ${dateLabel}`,
+      html,
+    });
+
+    return NextResponse.json({
+      sent: true,
+      recipient: DIGEST_RECIPIENT,
+      stats: {
+        done: recentlyDone.length,
+        inProgress: inProgress.length,
+        needsApproval: needsApproval.length,
+      },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/internal/daily-digest` — internal Next.js route called by the DevOpsEngineer Paperclip agent each morning (08:00 Europe/Berlin)
- Fetches three datasets from Paperclip in parallel: issues completed in last 24 h, all in-progress, in-review with `needs-approval` label
- Composes an HTML digest email and sends via Resend to `felix@foerderis.de`
- 8 Vitest tests covering auth, 24 h cutoff filtering, empty-state messages, error propagation, and email content

## Paperclip infrastructure (already live)

Routine **"Daily Digest — Tagesübersicht für Felix"** (`e1ce98ff`) is configured with cron `0 8 * * *` (Europe/Berlin), currently **paused** — activated after merge + deploy.

## Required env vars (Vercel)

| Var | Notes |
|-----|-------|
| `RESEND_API_KEY` | already set (from FRDAA-34) |
| `PAPERCLIP_API_URL` | already set |
| `PAPERCLIP_COMPANY_ID` | already set |
| `PAPERCLIP_SYSTEM_TOKEN` | already set |
| `INTERNAL_WEBHOOK_SECRET` | optional bearer auth guard |
| `PAPERCLIP_UI_URL` | defaults to `https://paperclip.ing` |

## Test plan
- [ ] CI Vitest passes
- [ ] Vercel preview smoke-test: `POST /api/internal/daily-digest` returns `{ sent: true }`
- [ ] Email arrives at felix@foerderis.de with all three sections
- [ ] After merge + deploy: activate Paperclip routine `e1ce98ff` (status → `active`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)