### PR TITLE
feat(web): FAQ page with accordion UI and FAQPage JSON-LD [FRDAA-51]

### DIFF
--- a/apps/web/app/faq/page.tsx
+++ b/apps/web/app/faq/page.tsx
@@ -1,0 +1,180 @@
+import { Button } from "@foerderis/ui";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "FAQ — Häufige Fragen zu Foerderis",
+  description:
+    "Antworten auf die häufigsten Fragen zu Foerderis: Kosten, Förderprogramme, Ablauf und Zusammenarbeit. Nur 10 % Erfolgshonorar — kein Risiko.",
+  alternates: {
+    canonical: "/faq",
+  },
+  openGraph: {
+    title: "FAQ — Häufige Fragen zu Foerderis",
+    description:
+      "Antworten auf die häufigsten Fragen zu Foerderis: Kosten, Förderprogramme, Ablauf und Zusammenarbeit.",
+    url: "https://foerderis.de/faq",
+  },
+};
+
+const FAQ_CATEGORIES = [
+  {
+    title: "Zum Modell",
+    items: [
+      {
+        question: "Was kostet Foerderis?",
+        answer:
+          "10 % der bewilligten Fördersumme — und nur dann, wenn die Förderung tatsächlich auf Ihrem Konto eingeht. Keine Einrichtungsgebühr, keine monatliche Pauschale, kein Retainer. Wenn wir keine passende Förderung finden oder der Antrag abgelehnt wird, zahlen Sie nichts.",
+      },
+      {
+        question: "Was passiert, wenn der Antrag abgelehnt wird?",
+        answer:
+          "Nichts. Sie zahlen in diesem Fall keinen Cent. Das Risiko liegt vollständig bei uns — deshalb prüfen wir sorgfältig, bevor wir einen Antrag stellen. Unser Interesse ist deckungsgleich mit Ihrem: Wir wollen, dass die Förderung bewilligt wird.",
+      },
+      {
+        question: "Wer eignet sich als Kunde?",
+        answer:
+          "Foerderis arbeitet mit deutschen kleinen und mittelständischen Unternehmen: 10 bis 250 Mitarbeiter, Umsatz 2 bis 50 Mio. €, Rechtsform GmbH, GmbH & Co. KG oder AG. Typische Branchen: Maschinenbau, Fertigung, Handwerk, mittelständische IT, Energie, Bau. Wir arbeiten nicht mit Pre-Revenue-Startups oder reinen Dienstleistungsunternehmen ohne greifbare Investitionen.",
+      },
+    ],
+  },
+  {
+    title: "Zur Förderung",
+    items: [
+      {
+        question: "Welche Förderprogramme deckt ihr ab?",
+        answer:
+          "Wir decken ein breites Spektrum an deutschen und europäischen Förderprogrammen ab — darunter KMU-innovativ (BMBF), IBB Pro FIT, EXIST, ZIM (Zentrales Innovationsprogramm Mittelstand), EFRE-Programme der Bundesländer sowie ausgewählte EU-Programme wie Horizon Europe. Unser KI-Team scannt täglich alle aktiven Ausschreibungen und gleicht sie mit Ihrem Unternehmensprofil ab.",
+      },
+      {
+        question: "Wie lange dauert es bis zum ersten Antrag?",
+        answer:
+          "Nach dem Erstgespräch und der Profil-Aufnahme dauert es in der Regel zwei bis vier Wochen bis zum ersten konkreten Antragsentwurf. Die Gesamtdauer hängt vom jeweiligen Förderprogramm ab: Manche Programme haben laufende Einreichungsfristen, andere feste Stichtage. Wir informieren Sie proaktiv über relevante Fristen.",
+      },
+      {
+        question: "Wie hoch sind typische Förderbeträge?",
+        answer:
+          "Das variiert stark nach Programm und Vorhaben. Kleine Innovationsprojekte starten häufig bei 50.000 €, größere Vorhaben über ZIM oder EFRE können 500.000 € und mehr erreichen. Wir legen keinen Mindestbetrag fest — aber wir prüfen ehrlich, ob der Aufwand für ein Vorhaben in einem gesunden Verhältnis zur erwarteten Fördersumme steht.",
+      },
+    ],
+  },
+  {
+    title: "Zur Zusammenarbeit",
+    items: [
+      {
+        question: "Was müssen wir als Kunde tun?",
+        answer:
+          "Im Wesentlichen zwei Dinge: Einmalig ein Erstgespräch zur Profil-Aufnahme (ca. 60 Minuten) und die Bereitstellung relevanter Unterlagen (Jahresabschluss, Projektbeschreibungen, Investitionspläne). Den Rest übernimmt unser KI-Team — Recherche, Antragsentwurf, Fristenmanagement und Compliance-Prüfung. Sie genehmigen Anträge vor der Einreichung, aber wir bereiten alles vor.",
+      },
+      {
+        question: "Wie ist der Ablauf Schritt für Schritt?",
+        answer:
+          "1. Erstgespräch: Wir erfassen Ihr Unternehmensprofil, Investitionsvorhaben und Förderhistorie.\n2. Matching: Unser KI-Team gleicht Ihr Profil mit allen aktuellen Förderprogrammen ab.\n3. Antragsentwurf: Wir formulieren revisionssichere Anträge und legen sie Ihnen zur Freigabe vor.\n4. Einreichung: Nach Ihrer Freigabe reichen wir den Antrag ein und überwachen den Prozess.\n5. Bewilligung: Bei Bewilligung und Zahlungseingang stellen wir 10 % in Rechnung.",
+      },
+      {
+        question: "Kann ich die Zusammenarbeit jederzeit beenden?",
+        answer:
+          "Ja. Es gibt keine Mindestlaufzeit und keine Kündigungsfristen. Sie können die Zusammenarbeit jederzeit beenden — ohne Kosten, ohne Begründung. Laufende Anträge, die bereits eingereicht wurden, werden noch abgeschlossen; für diese gilt weiterhin das Erfolgshonorar-Modell.",
+      },
+    ],
+  },
+];
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: FAQ_CATEGORIES.flatMap(({ items }) =>
+    items.map(({ question, answer }) => ({
+      "@type": "Question",
+      name: question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: answer,
+      },
+    })),
+  ),
+};
+
+export default function FaqPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: controlled static JSON-LD
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <main className="mx-auto max-w-3xl px-4 py-24">
+        <p className="mb-4 text-sm font-semibold uppercase tracking-widest text-muted-foreground">
+          Häufige Fragen
+        </p>
+        <h1 className="mb-4 text-4xl font-bold tracking-tight text-foreground">
+          Ihre Fragen zu Foerderis
+        </h1>
+        <p className="mb-16 text-lg text-muted-foreground">
+          Klare Antworten — ohne Marketingsprache.
+        </p>
+
+        <div className="space-y-12">
+          {FAQ_CATEGORIES.map(({ title, items }) => (
+            <section key={title} aria-labelledby={`cat-${title}`}>
+              <h2
+                id={`cat-${title}`}
+                className="mb-4 text-xs font-semibold uppercase tracking-widest text-muted-foreground"
+              >
+                {title}
+              </h2>
+              <div className="divide-y divide-border rounded-xl border border-border">
+                {items.map(({ question, answer }) => (
+                  <details
+                    key={question}
+                    className="group px-6 py-4 [&[open]>summary>svg]:rotate-180"
+                  >
+                    <summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-sm font-semibold text-foreground marker:hidden">
+                      {question}
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="shrink-0 text-muted-foreground transition-transform duration-200"
+                        aria-hidden="true"
+                      >
+                        <path d="m6 9 6 6 6-6" />
+                      </svg>
+                    </summary>
+                    <p className="mt-3 whitespace-pre-line text-sm leading-relaxed text-muted-foreground">
+                      {answer}
+                    </p>
+                  </details>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <div className="mt-16 rounded-xl border border-border bg-secondary/30 p-8 text-center">
+          <h2 className="mb-2 text-xl font-bold tracking-tight text-foreground">
+            Noch eine Frage?
+          </h2>
+          <p className="mb-6 text-sm text-muted-foreground">
+            Wir antworten innerhalb von zwei Werktagen.
+          </p>
+          <Button asChild>
+            <Link href="/#kontakt">Unverbindlich anfragen</Link>
+          </Button>
+        </div>
+
+        <div className="mt-10">
+          <Button asChild variant="outline">
+            <Link href="/">← Zurück zur Startseite</Link>
+          </Button>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,11 +1,43 @@
-import { ThemeProvider } from "@/components/theme-provider";
 import type { Metadata } from "next";
+import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 
+const SITE_URL = "https://foerderis.de";
+
+const TITLE = "Foerderis — Erfolgsbasierte Fördermittelberatung";
+const DESCRIPTION =
+  "Wir werden nur bezahlt, wenn Sie gefördert werden. Ein KI-Team sucht rund um die Uhr Förderprogramme für den deutschen Mittelstand — 10 % nur bei Bewilligung.";
+
 export const metadata: Metadata = {
-  title: "Foerderis — Fördermittelberatung auf Erfolgsbasis",
+  metadataBase: new URL(SITE_URL),
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    url: SITE_URL,
+    title: TITLE,
+    description: DESCRIPTION,
+    siteName: "Foerderis",
+    locale: "de_DE",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: TITLE,
+    description: DESCRIPTION,
+  },
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "ProfessionalService",
+  name: "Foerderis",
+  url: SITE_URL,
   description:
-    "Wir werden nur bezahlt, wenn Sie gefördert werden. Ein KI-Team sucht rund um die Uhr Förderprogramme für den deutschen Mittelstand — 10 % nur bei Bewilligung.",
+    "KI-gestützte Fördermittelberatung auf reiner Erfolgsbasis für den deutschen Mittelstand. 10 % Erfolgshonorar — nur bei bewilligter Förderung.",
+  areaServed: "DE",
 };
 
 export default function RootLayout({
@@ -15,6 +47,13 @@ export default function RootLayout({
 }) {
   return (
     <html lang="de" suppressHydrationWarning>
+      <head>
+        <script
+          type="application/ld+json"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: controlled static JSON-LD
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
       <body>
         <ThemeProvider
           attribute="class"

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -1,0 +1,60 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "Foerderis — Erfolgsbasierte Fördermittelberatung";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "#09090b",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+          padding: "64px",
+        }}
+      >
+        <div
+          style={{
+            color: "#ffffff",
+            fontSize: 72,
+            fontWeight: 700,
+            letterSpacing: "-2px",
+            marginBottom: 24,
+          }}
+        >
+          Foerderis
+        </div>
+        <div
+          style={{
+            color: "#a1a1aa",
+            fontSize: 36,
+            textAlign: "center",
+            maxWidth: 800,
+            lineHeight: 1.4,
+          }}
+        >
+          Erfolgsbasierte Fördermittelberatung für den deutschen Mittelstand
+        </div>
+        <div
+          style={{
+            color: "#22c55e",
+            fontSize: 28,
+            marginTop: 48,
+            fontWeight: 600,
+          }}
+        >
+          10 % Honorar — nur bei Bewilligung
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -215,7 +215,13 @@ export default function Home() {
           <p className="text-sm text-muted-foreground">
             © {new Date().getFullYear()} Foerderis. Alle Rechte vorbehalten.
           </p>
-          <nav aria-label="Footer-Navigation">
+          <nav aria-label="Footer-Navigation" className="flex gap-6">
+            <a
+              href="/faq"
+              className="text-sm text-muted-foreground underline-offset-4 hover:underline"
+            >
+              FAQ
+            </a>
             <a
               href="/impressum"
               className="text-sm text-muted-foreground underline-offset-4 hover:underline"


### PR DESCRIPTION
## Summary

- New `/faq` route at `apps/web/app/faq/page.tsx`
- 9 questions across 3 categories: **Zum Modell**, **Zur Förderung**, **Zur Zusammenarbeit**
- Native `<details>`/`<summary>` accordion — no new dependencies, fully accessible
- `FAQPage` JSON-LD structured data for Google rich results
- Footer link from landing page added
- CTA at bottom of FAQ page links back to `/#kontakt`

## Test plan

- [ ] Visit `/faq` — all accordion items open/close correctly
- [ ] Page source includes `"@type": "FAQPage"` JSON-LD
- [ ] Footer on `/` shows FAQ link
- [ ] `og:title` and canonical `/faq` present in page head
- [ ] Back-to-home button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)