### PR TITLE
feat(portal): echte Daten anbinden — Lead-Status, Dokumente [FRDAA-698]

### DIFF
--- a/apps/web/app/portal/(protected)/dashboard/page.tsx
+++ b/apps/web/app/portal/(protected)/dashboard/page.tsx
@@ -1,46 +1,110 @@
-/**
- * Kundenportal Dashboard — Stub (Phase 1)
- *
- * Placeholder UI for the customer dashboard.
- * Phase 2 will wire up real data from the `lead` and `customer` tables.
- */
-export default function DashboardPage() {
+import type { Lead } from "@foerderis/db";
+import { getAuthenticatedCustomer, getCustomerLeads } from "../queries";
+
+const STATUS_LABELS: Record<Lead["status"], string> = {
+  initial: "Neu",
+  in_progress: "In Bearbeitung",
+  submitted: "Eingereicht",
+  approved: "Bewilligt",
+  rejected: "Abgelehnt",
+};
+
+const STATUS_COLORS: Record<Lead["status"], string> = {
+  initial: "bg-slate-100 text-slate-700",
+  in_progress: "bg-blue-100 text-blue-700",
+  submitted: "bg-amber-100 text-amber-700",
+  approved: "bg-green-100 text-green-700",
+  rejected: "bg-red-100 text-red-700",
+};
+
+export default async function DashboardPage() {
+  const customer = await getAuthenticatedCustomer();
+
+  if (!customer) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold text-foreground">Ihr Dashboard</h1>
+        <div className="rounded-lg border border-border p-8 text-center text-muted-foreground">
+          Ihr Kundenprofil wird gerade eingerichtet. Bitte haben Sie einen Moment Geduld.
+        </div>
+      </div>
+    );
+  }
+
+  const leads = await getCustomerLeads(customer.id);
+
+  const counts = {
+    in_progress: leads.filter((l) => l.status === "in_progress").length,
+    submitted: leads.filter((l) => l.status === "submitted").length,
+    approved: leads.filter((l) => l.status === "approved").length,
+  };
+
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-foreground">Ihr Dashboard</h1>
         <p className="text-muted-foreground mt-1">
-          Hier sehen Sie den aktuellen Status Ihrer Förderanträge.
+          Willkommen, {customer.companyName}. Hier sehen Sie den aktuellen Status Ihrer
+          Förderanträge.
         </p>
       </div>
 
       {/* Status-Karten */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <StatusCard label="In Bearbeitung" value="–" />
-        <StatusCard label="Eingereicht" value="–" />
-        <StatusCard label="Bewilligt" value="–" />
+        <StatusCard label="In Bearbeitung" value={String(counts.in_progress)} />
+        <StatusCard label="Eingereicht" value={String(counts.submitted)} />
+        <StatusCard label="Bewilligt" value={String(counts.approved)} />
       </div>
 
-      {/* Anträge-Tabelle (Stub) */}
+      {/* Anträge-Tabelle */}
       <section>
-        <h2 className="text-lg font-semibold text-foreground mb-3">Meine Anträge</h2>
-        <div className="rounded-lg border border-border p-8 text-center text-muted-foreground">
-          Noch keine Förderanträge vorhanden.
-          <br />
-          Ihr Foerderis-Team meldet sich, sobald passende Programme gefunden wurden.
-        </div>
+        <h2 className="text-lg font-semibold text-foreground mb-3">Meine Förderanträge</h2>
+        {leads.length === 0 ? (
+          <div className="rounded-lg border border-border p-8 text-center text-muted-foreground">
+            Noch keine Förderanträge vorhanden.
+            <br />
+            Ihr Foerderis-Team meldet sich, sobald passende Programme gefunden wurden.
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border bg-muted/50">
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                    Förderprogramm
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                    Letzte Aktivität
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {leads.map((l) => (
+                  <tr key={l.id} className="border-b border-border last:border-0">
+                    <td className="px-4 py-3 text-foreground">{l.foerderprogrammName}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[l.status]}`}
+                      >
+                        {STATUS_LABELS[l.status]}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {l.lastActivityAt.toLocaleDateString("de-DE")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </section>
     </div>
   );
 }
 
-function StatusCard({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}) {
+function StatusCard({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-lg border border-border bg-card p-4">
       <p className="text-sm text-muted-foreground">{label}</p>

--- a/apps/web/app/portal/(protected)/dokumente/page.tsx
+++ b/apps/web/app/portal/(protected)/dokumente/page.tsx
@@ -1,0 +1,79 @@
+import type { Document } from "@foerderis/db";
+import { getAuthenticatedCustomer, getCustomerDocuments } from "../queries";
+
+const CATEGORY_LABELS: Record<Document["category"], string> = {
+  antrag: "Antrag",
+  checkliste: "Checkliste",
+  bescheid: "Bescheid",
+  sonstige: "Sonstige",
+};
+
+const CATEGORY_COLORS: Record<Document["category"], string> = {
+  antrag: "bg-blue-100 text-blue-700",
+  checkliste: "bg-amber-100 text-amber-700",
+  bescheid: "bg-green-100 text-green-700",
+  sonstige: "bg-slate-100 text-slate-700",
+};
+
+export default async function DokumentePage() {
+  const customer = await getAuthenticatedCustomer();
+
+  if (!customer) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold text-foreground">Dokumente</h1>
+        <div className="rounded-lg border border-border p-8 text-center text-muted-foreground">
+          Ihr Kundenprofil wird gerade eingerichtet.
+        </div>
+      </div>
+    );
+  }
+
+  const documents = await getCustomerDocuments(customer.id);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Ihre Dokumente</h1>
+        <p className="text-muted-foreground mt-1">
+          Hier finden Sie alle Unterlagen zu Ihren Förderanträgen.
+        </p>
+      </div>
+
+      {documents.length === 0 ? (
+        <div className="rounded-lg border border-border p-8 text-center text-muted-foreground">
+          Noch keine Dokumente vorhanden.
+          <br />
+          Sobald Unterlagen für Sie bereitstehen, erscheinen sie hier.
+        </div>
+      ) : (
+        <div className="grid gap-3">
+          {documents.map((doc) => (
+            <a
+              key={doc.id}
+              href={doc.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-between rounded-lg border border-border bg-card p-4 transition-colors hover:bg-muted/50"
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-lg">📄</span>
+                <div>
+                  <p className="text-sm font-medium text-foreground">{doc.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {doc.createdAt.toLocaleDateString("de-DE")}
+                  </p>
+                </div>
+              </div>
+              <span
+                className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${CATEGORY_COLORS[doc.category]}`}
+              >
+                {CATEGORY_LABELS[doc.category]}
+              </span>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/portal/(protected)/layout.tsx
+++ b/apps/web/app/portal/(protected)/layout.tsx
@@ -1,10 +1,16 @@
 import { auth } from "@foerderis/db";
 import { headers } from "next/headers";
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 // BETTER_AUTH_SECRET and DATABASE_URL are only available at runtime, not
 // during next build — force dynamic rendering for the entire portal subtree.
 export const dynamic = "force-dynamic";
+
+const NAV_ITEMS = [
+  { href: "/portal/dashboard", label: "Dashboard" },
+  { href: "/portal/dokumente", label: "Dokumente" },
+];
 
 /**
  * Portal protected layout — server-side auth guard.
@@ -13,7 +19,7 @@ export const dynamic = "force-dynamic";
  *
  * File structure note: Next.js route group `(protected)` groups auth-guarded
  * routes under /portal without adding a URL segment, yielding clean URLs like
- * /portal/dashboard, /portal/antraege, etc.
+ * /portal/dashboard, /portal/dokumente, etc.
  */
 export default async function PortalLayout({
   children,
@@ -32,7 +38,20 @@ export default async function PortalLayout({
     <div className="min-h-screen bg-background">
       <header className="border-b border-border">
         <div className="mx-auto max-w-5xl px-4 py-4 flex items-center justify-between">
-          <span className="font-semibold text-foreground">Foerderis Kundenportal</span>
+          <div className="flex items-center gap-6">
+            <span className="font-semibold text-foreground">Foerderis Kundenportal</span>
+            <nav className="flex gap-4">
+              {NAV_ITEMS.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+          </div>
           <span className="text-sm text-muted-foreground">{session.user.email}</span>
         </div>
       </header>

--- a/apps/web/app/portal/(protected)/queries.ts
+++ b/apps/web/app/portal/(protected)/queries.ts
@@ -1,0 +1,37 @@
+import { auth, customer, db, document, eq, lead } from "@foerderis/db";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+/**
+ * Get the authenticated customer record. Redirects to login if not authenticated.
+ */
+export async function getAuthenticatedCustomer() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) redirect("/portal/login");
+
+  const rows = await db
+    .select()
+    .from(customer)
+    .where(eq(customer.userId, session.user.id))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+/**
+ * Get all leads for a customer.
+ */
+export async function getCustomerLeads(customerId: string) {
+  return db.select().from(lead).where(eq(lead.customerId, customerId)).orderBy(lead.lastActivityAt);
+}
+
+/**
+ * Get all documents for a customer.
+ */
+export async function getCustomerDocuments(customerId: string) {
+  return db
+    .select()
+    .from(document)
+    .where(eq(document.customerId, customerId))
+    .orderBy(document.createdAt);
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,3 +2,4 @@ export { db } from "./client";
 export { auth } from "./auth";
 export type { Session, User } from "./auth";
 export * from "./schema";
+export { eq } from "drizzle-orm";

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -107,3 +107,24 @@ export const lead = pgTable("lead", {
 
 export type Lead = typeof lead.$inferSelect;
 export type NewLead = typeof lead.$inferInsert;
+
+/**
+ * Documents available to a customer (Antragsunterlagen, Checklisten, etc.).
+ */
+export const document = pgTable("document", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  customerId: uuid("customer_id")
+    .notNull()
+    .references(() => customer.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  category: text("category", {
+    enum: ["antrag", "checkliste", "bescheid", "sonstige"],
+  })
+    .notNull()
+    .default("sonstige"),
+  url: text("url").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export type Document = typeof document.$inferSelect;
+export type NewDocument = typeof document.$inferInsert;


### PR DESCRIPTION
## Summary
- **Dashboard** zeigt jetzt echte Lead-Daten: Status-Karten und Antrags-Tabelle mit Förderprogramm, Status-Badge und letzter Aktivität
- **Dokumente-Seite** (`/portal/dokumente`) listet kundenspezifische Dokumente mit Kategorie-Badges
- **Navigation** im Portal-Header zwischen Dashboard und Dokumente
- **Schema**: neues `document` Table für Kundendokumente
- **Queries**: Server-seitige Datenabfragen via Drizzle ORM

## Hinweis
Nach Merge muss `drizzle-kit push` ausgeführt werden, um die `document` Tabelle in der DB anzulegen.

## Test plan
- [x] TypeScript kompiliert fehlerfrei
- [x] Biome-Check sauber
- [ ] Dashboard zeigt Lead-Daten korrekt an
- [ ] Dokumente-Seite zeigt Dokumente korrekt an
- [ ] Navigation funktioniert
- [ ] Auth-Guard redirectet korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)